### PR TITLE
Draft of new REST API using DRF

### DIFF
--- a/archivebox.egg-info/SOURCES.txt
+++ b/archivebox.egg-info/SOURCES.txt
@@ -21,6 +21,9 @@ archivebox.egg-info/dependency_links.txt
 archivebox.egg-info/entry_points.txt
 archivebox.egg-info/requires.txt
 archivebox.egg-info/top_level.txt
+archivebox/api/__init__.py
+archivebox/api/serializers.py
+archivebox/api/views.py
 archivebox/cli/__init__.py
 archivebox/cli/archivebox_add.py
 archivebox/cli/archivebox_config.py

--- a/archivebox.egg-info/requires.txt
+++ b/archivebox.egg-info/requires.txt
@@ -4,6 +4,7 @@ mypy-extensions==0.4.3
 base32-crockford==0.3.0
 django==3.0.8
 django-extensions==3.0.3
+djangorestframework==3.12.2
 dateparser
 ipython
 youtube-dl

--- a/archivebox/api/__init__.py
+++ b/archivebox/api/__init__.py
@@ -1,0 +1,7 @@
+__package__ = 'archivebox.api'
+
+from rest_framework import routers
+from .views import SnapshotViewset
+
+router = routers.DefaultRouter()
+router.register(r'snapshots', SnapshotViewset)

--- a/archivebox/api/serializers.py
+++ b/archivebox/api/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+
+from core.models import Snapshot
+
+class SnapshotSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Snapshot
+        fields = ("id", "url", "title", "added", "updated", "bookmarked")

--- a/archivebox/api/views.py
+++ b/archivebox/api/views.py
@@ -1,0 +1,10 @@
+__package__ = 'archivebox.api'
+
+from rest_framework import viewsets, generics, mixins
+
+from core.models import Snapshot
+from .serializers import SnapshotSerializer
+
+class SnapshotViewset(viewsets.ReadOnlyModelViewSet):
+    queryset = Snapshot.objects.all()
+    serializer_class = SnapshotSerializer

--- a/archivebox/core/settings.py
+++ b/archivebox/core/settings.py
@@ -44,8 +44,13 @@ INSTALLED_APPS = [
     'core',
 
     'django_extensions',
+    'rest_framework',
 ]
 
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 100
+}
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/archivebox/core/urls.py
+++ b/archivebox/core/urls.py
@@ -6,11 +6,11 @@ from django.conf import settings
 from django.views.generic.base import RedirectView
 
 from core.views import MainIndex, LinkDetails, PublicArchiveView, AddView
+from api import router
 
-
-# print('DEBUG', settings.DEBUG)
 
 urlpatterns = [
+    path('api/', include(router.urls)),
     path('robots.txt', static.serve, {'document_root': settings.OUTPUT_DIR, 'path': 'robots.txt'}),
     path('favicon.ico', static.serve, {'document_root': settings.OUTPUT_DIR, 'path': 'favicon.ico'}),
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setuptools.setup(
         "base32-crockford==0.3.0",
         "django==3.0.8",
         "django-extensions==3.0.3",
+        "djangorestframework==3.12.2",
 
         "dateparser",
         "ipython",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,7 +1,9 @@
 import os
+import time
 import subprocess
 
 import pytest
+import requests
 
 @pytest.fixture
 def process(tmp_path):
@@ -26,3 +28,44 @@ def disable_extractors_dict():
         "SAVE_ARCHIVE_DOT_ORG": "false"
     })
     return env
+
+class Server:
+    base: str
+    process: subprocess.Popen
+    
+    def start(self, base="0.0.0.0:8000"):
+        self.base = base
+        self.process = subprocess.Popen(["archivebox", "server", self.base])
+
+        count = 0
+
+        while not self._server_started():
+            if count > 10:
+                self.stop()
+                raise Exception('Server not started in 10s')
+
+            time.sleep(1)
+            count += 1
+
+    def stop(self):
+        if self.process is not None:
+            self.process.kill()
+
+    def _server_started(self):
+        try:
+            response = self.get('/')
+            return response.status_code == 200
+        except requests.exceptions.ConnectionError:
+            return False
+
+    def get(self, url):
+        return requests.get(f'http://{self.base}{url}')
+
+@pytest.fixture
+def server(tmp_path, process):
+    server = Server()
+    server.start()
+
+    yield server
+
+    server.stop()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,25 @@
+import subprocess
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from .fixtures import *
+
+def test_get_snapshots(server, disable_extractors_dict):
+    """
+    Ensure we can get snaphots from the API.
+    """
+    url = "http://127.0.0.1:8080/static/example.com.html"
+    subprocess.run(
+        ["archivebox", "add", "--depth=0", url],
+        capture_output=True,
+        env=disable_extractors_dict
+    )
+    response = server.get('/api/snapshots/')
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body.get('count') == 1
+    snapshot, = body.get('results')
+    assert snapshot.get('url') == url


### PR DESCRIPTION
This pulls in DRF to configure our API. Pretty straightforward binding of a view
to a serializer & a model and making the data available. For this first pass,
we're using the model even though it's currently unstable. From a feature
standpoint, we get a lot for free from DRF with very little code, including
pagination. The `list_links` method loads all of the snapshots, which would
require pagination to be implemented manually on the entire list of snapshots,
which won't work well on large databases. Because archivebox is a CLI first
and a web application second, the way Exceptions are thrown and errors
logged doesn't always make those methods conducive to integrating w/ an API.

On the testing side, this shows up in how we're configuring things. The
`setup_django` function doesn't fully work when passing `out_path`;
Some variables in the Django settings aren't updated or configured correctly.
Instead, we use `subprocess` the same way the other tests do to start up the
server and hit it with `requests`.

# Summary

This is obviously a work in progress but wanted to get some feedback on the
direction. It would be helpful if the API functions exposed by archivebox were
more decoupled from the CLI context specifically, but I think we're going to
want to bind the Models directly (at least for querying).

# Related issues

#496 

# Changes these areas

- [ ] Bugfixes
- [X] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
