### PR TITLE
Fix string checks in schedule

### DIFF
--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -938,7 +938,7 @@ def schedule(add: bool=False,
 
     if every or add:
         every = every or 'day'
-        quoted = lambda s: f'"{s}"' if s and ' ' in s else s
+        quoted = lambda s: f'"{s}"' if s and ' ' in str(s) else str(s)
         cmd = [
             'cd',
             quoted(out_dir),


### PR DESCRIPTION
`s` comes through as a `PosixPath`, so both the `' ' in s` & return value, later
used by `join`, complain.

# Summary

I got errors running `schedule` related to the above.

# Related issues

N/A

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
