### PR TITLE
Parse Snapshot#timestamp with `fromtimestamp`

### DIFF
--- a/archivebox/core/models.py
+++ b/archivebox/core/models.py
@@ -1,6 +1,7 @@
 __package__ = 'archivebox.core'
 
 import uuid
+from datetime import datetime
 
 from django.db import models, transaction
 from django.utils.functional import cached_property
@@ -98,7 +99,7 @@ class Snapshot(models.Model):
 
     @cached_property
     def bookmarked(self):
-        return parse_date(self.timestamp)
+        return datetime.fromtimestamp(float(self.timestamp))
 
     @cached_property
     def is_archived(self):


### PR DESCRIPTION
Since we know what this is supposed to be, we don't need to use the "best
guess" version from `parse_date`. Some values I was getting from the Pocket
API produced weird/inconsistent results.


# Summary

I got some weird results with some timestamps from the Pocket API, which
_could_ just be issues in Pocket's data, but as I was trying to solve them, I
realized we had this "best guess" approach for parsing a date, while we
know for sure this is a timestamp and could be parsed as one.

# Related issues

N/A but wondering if maybe `bookmarked` should be reified into the DB?
Would be helpful for the REST API, so we could sort by bookmarked.

# Changes these areas

- [X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
