### PR TITLE
Hotfix public page search

### DIFF
--- a/archivebox/core/views.py
+++ b/archivebox/core/views.py
@@ -92,12 +92,13 @@ class PublicArchiveView(ListView):
     template = 'snapshot_list.html'
     model = Snapshot
     paginate_by = 100
+    ordering = ['title']
 
     def get_queryset(self, **kwargs): 
         qs = super().get_queryset(**kwargs) 
         query = self.request.GET.get('q')
         if query:
-            qs = Snapshot.objects.filter(title__icontains=query)
+            qs = qs.filter(title__icontains=query)
         for snapshot in qs:
             snapshot.icons = get_icons(snapshot) 
         return qs


### PR DESCRIPTION
No ordering causes warning and fallback to default unfiltered QuerySet


# Summary

No ordering causes warning and fallback to default unfiltered QuerySet


# Related issues


# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
