### PR TITLE
fix "inconsisntencies" typo in error message

### DIFF
--- a/archivebox/index/__init__.py
+++ b/archivebox/index/__init__.py
@@ -233,7 +233,7 @@ def write_main_index(links: List[Link], out_dir: Path=OUTPUT_DIR, finished: bool
 
     except (KeyboardInterrupt, SystemExit):
         stderr('[!] Warning: Still writing index to disk...', color='lightyellow')
-        stderr('    Run archivebox init to fix any inconsisntencies from an ungraceful exit.')
+        stderr('    Run archivebox init to fix any inconsistencies from an ungraceful exit.')
         with timed_index_update(out_dir / SQL_INDEX_FILENAME):
             write_sql_main_index(links, out_dir=out_dir)
             os.chmod(out_dir / SQL_INDEX_FILENAME, int(OUTPUT_PERMISSIONS, base=8)) # set here because we don't write it with atomic writes


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

I noticed a small typo in an error message, so this PR fixes it. `s/inconsisntencies/inconsistencies/`

<!--e.g. This PR fixes ABC or adds the ability to do XYZ...-->

# Changes these areas

- [ ] Bugfixes
- [ ] Feature behavior
- [x] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
