### PR TITLE
Set info as default logging level for sonic

### DIFF
--- a/etc/sonic/config.cfg
+++ b/etc/sonic/config.cfg
@@ -6,7 +6,7 @@
 
 [server]
 
-log_level = "debug"
+log_level = "info"
 
 
 [channel]


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

<!--e.g. This PR fixes ABC or adds the ability to do XYZ...-->

# Related issues

<!-- e.g. #123 or Roadmap goal # https://github.com/pirate/ArchiveBox/wiki/Roadmap -->

# Changes these areas

- [ ] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [x] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
