### PR TITLE
Fix simple typo, timstamp -> timestamp

### DIFF
--- a/archivebox/index/__init__.py
+++ b/archivebox/index/__init__.py
@@ -124,7 +124,7 @@ def validate_links(links: Iterable[Link]) -> List[Link]:
     timer = TimedProgress(TIMEOUT * 4)
     try:
         links = archivable_links(links)  # remove chrome://, about:, mailto: etc.
-        links = sorted_links(links)      # deterministically sort the links based on timstamp, url
+        links = sorted_links(links)      # deterministically sort the links based on timestamp, url
         links = fix_duplicate_links(links)  # merge/dedupe duplicate timestamps & urls
     finally:
         timer.end()


### PR DESCRIPTION
There is a small typo in archivebox/index/__init__.py.

Should read `timestamp` rather than `timstamp`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md