### PR TITLE
Publish tag to Docker Hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,15 +52,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
       
-      - name: Get publish tag
-        id: publish
+      - name: Prepare tags to publish
+        id: prep
         run: |
+          # Always publish to latest.
+          TAGS="${{ secrets.DOCKER_USERNAME }}/archivebox:latest,archivebox/archivebox:latest"
           if [[ $GITHUB_REF == refs/tags/* ]]; then
-            TAG="${GITHUB_REF#refs/tags/}"
+            VERSION="${GITHUB_REF#refs/tags/}"
+            MINOR=${VERSION%.*}
+            MAJOR=${MINOR%.*}
+            TAGS="$TAGS,${{ secrets.DOCKER_USERNAME }}/archivebox:$VERSION,archivebox/archivebox:$VERSION"
+            TAGS="$TAGS,${{ secrets.DOCKER_USERNAME }}/archivebox:$MINOR,archivebox/archivebox:$MINOR"
+            TAGS="$TAGS,${{ secrets.DOCKER_USERNAME }}/archivebox:$MAJOR,archivebox/archivebox:$MAJOR"
           else
-            TAG=$GITHUB_SHA
+            VERSION=$GITHUB_SHA
+            TAGS="$TAGS,${{ secrets.DOCKER_USERNAME }}/archivebox:$VERSION,archivebox/archivebox:$VERSION"
           fi
-          echo ::set-output name=tag::${TAG}
+
+          echo ::set-output name=tags::${TAGS}
         env:
           GITHUB_REF: ${{ github.ref }}
           GITHUB_SHA: ${{ github.sha }}
@@ -73,11 +82,7 @@ jobs:
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags: |
-            ${{ secrets.DOCKER_USERNAME }}/archivebox:latest
-            ${{ secrets.DOCKER_USERNAME }}/archivebox:${{ steps.publish.outputs.tag }}
-            archivebox/archivebox:latest
-            archivebox/archivebox:${{ steps.publish.outputs.tag }}
+          tags: ${{ steps.prep.outputs.tags }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,8 +55,8 @@ jobs:
       - name: Get publish tag
         id: publish
         run: |
-          if [[ $GITHUB_REF != refs/tags/* ]]; then
-            TAG="${GITHUB_REF##*/}"
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
           else
             TAG=$GITHUB_SHA
           fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,6 +52,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
       
+      - name: Get publish tag
+        id: publish
+        run: |
+          if [[ $GITHUB_REF != refs/tags/* ]]; then
+            TAG="${GITHUB_REF##*/}"
+          else
+            TAG=$GITHUB_SHA
+          fi
+          echo ::set-output name=tag::${TAG}
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_SHA: ${{ github.sha }}
+      
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
@@ -62,12 +75,12 @@ jobs:
           push: true
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/archivebox:latest
-            ${{ secrets.DOCKER_USERNAME }}/archivebox:${{ github.sha }}
+            ${{ secrets.DOCKER_USERNAME }}/archivebox:${{ steps.publish.outputs.tag }}
             archivebox/archivebox:latest
-            archivebox/archivebox:${{ github.sha }}
+            archivebox/archivebox:${{ steps.publish.outputs.tag }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-      
+
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
This tags the versions released on Docker Hub so we
can rely on those versions rather than the sha.

# Summary

After 0.5.3 was published, I went to Docker Hub looking for an 0.5.3 tag so I could lock my containers to that
version but didn't find one. After poking around the GitHub workflow, I think I've got a solution that will
correctly publish a new version but this is hard to test. Not sure if you have a suggestion there besides
pushing a forked version (which I could do) or just... merging & seeing if it works and testing on the next tag?

# Related issues

N/A

# Changes these areas

- [ ] Bugfixes
- [x] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
