### PR TITLE
Fix issue #617 by using mark_safe in combination with format_html

### DIFF
--- a/archivebox/index/html.py
+++ b/archivebox/index/html.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import List, Optional, Iterator, Mapping
 from pathlib import Path
 
-from django.utils.html import format_html
+from django.utils.html import format_html, mark_safe
 from collections import defaultdict
 
 from .schema import Link
@@ -161,4 +161,4 @@ def snapshot_icons(snapshot) -> str:
             output += '<a href="{}" class="exists-{}" title="{}">{}</a> '.format(canon["archive_org_path"], str(exists),
                                                                                         "archive_org", icons.get("archive_org", "?"))
 
-    return format_html(f'<span class="files-icons" style="font-size: 1.1em; opacity: 0.8">{output}<span>')
+    return format_html('<span class="files-icons" style="font-size: 1.1em; opacity: 0.8">{}<span>', mark_safe(output))

--- a/archivebox/index/html.py
+++ b/archivebox/index/html.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import List, Optional, Iterator, Mapping
 from pathlib import Path
 
-from django.utils.html import format_html, mark_safe
+from django.utils.html import format_html
 from collections import defaultdict
 
 from .schema import Link

--- a/archivebox/index/html.py
+++ b/archivebox/index/html.py
@@ -161,4 +161,4 @@ def snapshot_icons(snapshot) -> str:
             output += '<a href="{}" class="exists-{}" title="{}">{}</a> '.format(canon["archive_org_path"], str(exists),
                                                                                         "archive_org", icons.get("archive_org", "?"))
 
-    return format_html('<span class="files-icons" style="font-size: 1.1em; opacity: 0.8">{}<span>', mark_safe(output))
+    return format_html('<span class="files-icons" style="font-size: 1.1em; opacity: 0.8">{}<span>', output)


### PR DESCRIPTION
I have no experience with Django, so all I'm really going off of is this
stackoverflow

https://stackoverflow.com/a/64498319

which cited this bit of Django documentation:

https://docs.djangoproject.com/en/3.1/ref/utils/#django.utils.html.format_html

After using this method, I no longer get the 500 error or KeyError
exception, and can browse the local server and interact with the single
entry in it (the problematic URL in ArchiveBox#617 with curly braces).

Whether this is the "right" method or not, I have no idea. But it is at
least a start.

# Summary

Fixes 500 errors on /public/ URL, experienced in issue #617. May not completely resolve all issues in #617.

# Related issues

None.

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
