### PR TITLE
Set archivebox UID/GID via envvars

### DIFF
--- a/bin/docker_entrypoint.sh
+++ b/bin/docker_entrypoint.sh
@@ -4,11 +4,11 @@ DATA_DIR="${DATA_DIR:-/data}"
 ARCHIVEBOX_USER="${ARCHIVEBOX_USER:-archivebox}"
 
 # Set the archivebox user UID & GID
-if [[ -n "$ARCHIVEBOX_UID" && "$ARCHIVEBOX_UID" != 0 ]]; then
-    usermod -u "$ARCHIVEBOX_UID" "$ARCHIVEBOX_USER" > /dev/null 2>&1
+if [[ -n "$PUID" && "$PUID" != 0 ]]; then
+    usermod -u "$PUID" "$ARCHIVEBOX_USER" > /dev/null 2>&1
 fi
-if [[ -n "$ARCHIVEBOX_GID" && "$ARCHIVEBOX_GID" != 0 ]]; then
-    groupmod -g "$ARCHIVEBOX_GID" "$ARCHIVEBOX_USER" > /dev/null 2>&1
+if [[ -n "$PGID" && "$PGID" != 0 ]]; then
+    groupmod -g "$PGID" "$ARCHIVEBOX_USER" > /dev/null 2>&1
 fi
 
 # Set the permissions of the data dir to match the archivebox user

--- a/bin/docker_entrypoint.sh
+++ b/bin/docker_entrypoint.sh
@@ -3,6 +3,14 @@
 DATA_DIR="${DATA_DIR:-/data}"
 ARCHIVEBOX_USER="${ARCHIVEBOX_USER:-archivebox}"
 
+# Set the archivebox user UID & GID
+if [[ -n "$ARCHIVEBOX_UID" && "$ARCHIVEBOX_UID" != 0 ]]; then
+    usermod -u "$ARCHIVEBOX_UID" "$ARCHIVEBOX_USER" > /dev/null 2>&1
+fi
+if [[ -n "$ARCHIVEBOX_GID" && "$ARCHIVEBOX_GID" != 0 ]]; then
+    groupmod -g "$ARCHIVEBOX_GID" "$ARCHIVEBOX_USER" > /dev/null 2>&1
+fi
+
 # Set the permissions of the data dir to match the archivebox user
 if [[ -d "$DATA_DIR/archive" ]]; then
     # check data directory permissions


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

This PR restores the ability to set the UID/GID of the archivebox user in docker via environment variables.

# Changes these areas

- [ ] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [x] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
