### PR TITLE
point to master image, not latest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ version: '2.4'
 services:
     archivebox:
         # build: .                              # for developers working on archivebox
-        image: ${DOCKER_IMAGE:-archivebox/archivebox:latest}
+        image: ${DOCKER_IMAGE:-archivebox/archivebox:master}
         command: server --quick-init 0.0.0.0:8000
         ports:
             - 8000:8000


### PR DESCRIPTION
# Summary

Following the docker-compose quick-start guide, used "latest" tagged docker image in compose file as indicated. Returned an exec error on my arm64 raspi 3b+. Seems like this needs to be "master" tag to really support multi-arch... Worked when I changed it to "master" tagged image on my machine.

# Related issues

# Changes these areas

- [ ] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [x] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
