### PR TITLE
Arch Linux AUR bug fixes backport

### DIFF
--- a/archivebox/core/apps.py
+++ b/archivebox/core/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class CoreConfig(AppConfig):
     name = 'core'
-    default_auto_field = 'django.db.models.UUIDField'
+    default_auto_field = 'django.db.models.BigAutoField'

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import json
 import setuptools
 from setuptools.command.test import test
+from setuptools import find_packages
 
 from pathlib import Path
 
@@ -99,7 +100,7 @@ setuptools.setup(
     setup_requires=SETUP_REQUIRES,
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
-    packages=[PKG_NAME],
+    packages=[PKG_NAME] + find_packages(),
     include_package_data=True,   # see MANIFEST.in
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

Few changes required for ArchiveBox Arch Linux AUR Packages. 
1. https://github.com/ArchiveBox/ArchiveBox/commit/4223801a04fac1bdaf05f92d3a27582d0a1e4796 addresses a minor Django change which created a `ValueError` when trying to run `archivebox init` on Arch Linux,
```python
  File "/usr/lib/python3.9/site-packages/django/db/models/options.py", line 246, in _get_default_pk_class
    raise ValueError(
ValueError: Primary key 'django.db.models.UUIDField' referred by core.apps.CoreConfig.default_auto_field must subclass AutoField.
```

2. The `vendor` and other subdirectories were not included in the `setup.py` install because only the main package (`archivebox`) was included, not the subdirectories within. 

Feel free to close this PR, if it seems redundant, or let me know if I can improve it. 

# Related issues

#738, #728


# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
