### PR TITLE
fix: use 644 instead of 755 for the configuration file

### DIFF
--- a/archivebox/config.py
+++ b/archivebox/config.py
@@ -74,7 +74,7 @@ CONFIG_SCHEMA: Dict[str, ConfigDefaultDict] = {
         'ONLY_NEW':                 {'type': bool,  'default': True},
         'TIMEOUT':                  {'type': int,   'default': 60},
         'MEDIA_TIMEOUT':            {'type': int,   'default': 3600},
-        'OUTPUT_PERMISSIONS':       {'type': str,   'default': '755'},
+        'OUTPUT_PERMISSIONS':       {'type': str,   'default': '644'},
         'RESTRICT_FILE_NAMES':      {'type': str,   'default': 'windows'},
         'URL_BLACKLIST':            {'type': str,   'default': r'\.(css|js|otf|ttf|woff|woff2|gstatic\.com|googleapis\.com/css)(\?.*)?$'},  # to avoid downloading code assets as their own pages
     },


### PR DESCRIPTION


<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

ArchiveBox attempted to create configuration files 'ArchiveBox.conf'
which had execute permissions '+x' for everyone, which didnt seem safe
which seems to introduce security vulnerabilities.


# Related issues
None

# Changes these areas

- [ ] Bugfixes
- [x] Feature behavior
- [ ] Command line interface
- [x] Configuration options
- [ ] Internal architecture
- [x] Snapshot data layout on disk
