### PR TITLE
Exempt /add route from CSRF

### DIFF
--- a/archivebox/core/views.py
+++ b/archivebox/core/views.py
@@ -11,6 +11,8 @@ from django.views.generic.list import ListView
 from django.views.generic import FormView
 from django.db.models import Q
 from django.contrib.auth.mixins import UserPassesTestMixin
+from django.views.decorators.csrf import csrf_exempt
+from django.utils.decorators import method_decorator
 
 from core.models import Snapshot
 from core.forms import AddLinkForm
@@ -236,7 +238,7 @@ class PublicIndexView(ListView):
         else:
             return redirect(f'/admin/login/?next={self.request.path}')
 
-
+@method_decorator(csrf_exempt, name='dispatch')
 class AddView(UserPassesTestMixin, FormView):
     template_name = "add.html"
     form_class = AddLinkForm


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

This PR exempts the `/add` route from CSRF checks, so the [ArchiveBox Exporter](https://github.com/tjhorner/archivebox-exporter) extension can use it as a pseudo-API while a real API is in the works.

# Related issues

#577

# Changes these areas

- [ ] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [x] Internal architecture
- [ ] Snapshot data layout on disk
