### PR TITLE
Discard Referer header from iframe and link to original URL

### DIFF
--- a/archivebox/templates/core/snapshot.html
+++ b/archivebox/templates/core/snapshot.html
@@ -416,12 +416,14 @@
                     {% endif %}
                     <div class="col-lg-2">
                         <div class="card">
-                            <iframe class="card-img-top" src="{{url}}" sandbox="allow-same-origin allow-top-navigation-by-user-activation allow-scripts allow-forms" scrolling="no" loading="lazy"></iframe>
+                            <iframe class="card-img-top" src="{{url}}" sandbox="allow-same-origin allow-top-navigation-by-user-activation allow-scripts allow-forms" scrolling="no" loading="lazy" referrerpolicy="no-referrer"></iframe>
                             <div class="card-body">
-                                <a href="{{url}}" title="Open in new tab..." target="_blank" rel="noopener">
+                                <a href="{{url}}" title="Open in new tab..." target="_blank" rel="noopener" referrerpolicy="no-referrer">
                                     <p class="card-text"><code>🌐 {{domain}}</code></p>
                                 </a>
-                                <a href="{{url}}" target="preview" id="original-btn"><h4 class="card-title">Original</h4></a>
+                                <a href="{{url}}" target="preview" id="original-btn" referrerpolicy="no-referrer">
+                                    <h4 class="card-title">Original</h4>
+                                </a>
                           </div>
                         </div>
                     </div>


### PR DESCRIPTION
# Summary

Add `referrerpolicy` attribute to `iframe` and `a` tag to avoid sending `Referer` header for privacy

reference for [iframe tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-referrerpolicy) and
[a tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-referrerpolicy)

# Related issues

None

# Changes these areas

- [ ] Bugfixes
- [x] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
