### PR TITLE
healthcheck endpoint

### DIFF
--- a/archivebox/core/urls.py
+++ b/archivebox/core/urls.py
@@ -6,7 +6,7 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.conf import settings
 from django.views.generic.base import RedirectView
 
-from core.views import HomepageView, SnapshotView, PublicIndexView, AddView
+from core.views import HomepageView, SnapshotView, PublicIndexView, AddView, HealthCheckView
 
 
 # print('DEBUG', settings.DEBUG)
@@ -24,14 +24,16 @@ urlpatterns = [
 
     path('admin/core/snapshot/add/', RedirectView.as_view(url='/add/')),
     path('add/', AddView.as_view(), name='add'),
-    
+
     path('accounts/login/', RedirectView.as_view(url='/admin/login/')),
     path('accounts/logout/', RedirectView.as_view(url='/admin/logout/')),
 
 
     path('accounts/', include('django.contrib.auth.urls')),
     path('admin/', admin.site.urls),
-    
+
+    path('health/', HealthCheckView.as_view(), name='healthcheck'),
+
     path('index.html', RedirectView.as_view(url='/')),
     path('index.json', static.serve, {'document_root': settings.OUTPUT_DIR, 'path': 'index.json'}),
     path('', HomepageView.as_view(), name='Home'),

--- a/archivebox/core/views.py
+++ b/archivebox/core/views.py
@@ -38,7 +38,7 @@ class HomepageView(View):
 
         if PUBLIC_INDEX:
             return redirect('/public')
-        
+
         return redirect(f'/admin/login/?next={request.path}')
 
 
@@ -205,7 +205,7 @@ class SnapshotView(View):
                 content_type="text/html",
                 status=404,
             )
-        
+
 
 class PublicIndexView(ListView):
     template_name = 'public_index.html'
@@ -220,7 +220,7 @@ class PublicIndexView(ListView):
             'FOOTER_INFO': FOOTER_INFO,
         }
 
-    def get_queryset(self, **kwargs): 
+    def get_queryset(self, **kwargs):
         qs = super().get_queryset(**kwargs)
         query = self.request.GET.get('q')
         if query and query.strip():
@@ -249,7 +249,7 @@ class AddView(UserPassesTestMixin, FormView):
             url = self.request.GET.get('url', None)
             if url:
                 return {'url': url if '://' in url else f'https://{url}'}
-        
+
         return super().get_initial()
 
     def test_func(self):
@@ -295,3 +295,18 @@ class AddView(UserPassesTestMixin, FormView):
             "form": AddLinkForm()
         })
         return render(template_name=self.template_name, request=self.request, context=context)
+
+
+class HealthCheckView(View):
+    """
+    A Django view that renders plain text "OK" for service discovery tools
+    """
+    def get(self, request):
+        """
+        Handle a GET request
+        """
+        return HttpResponse(
+            'OK',
+            content_type='text/plain',
+            status=200
+        )


### PR DESCRIPTION
# Summary

This PR adds a `/health` endpoint which does nothing more than returning plaintext `OK` response. It is useful for service discovery tools (consul/kubernetes etc.), to quickly say, that service is alive and running.

# Changes these areas

- [ ] Bugfixes
- [x] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
