### PR TITLE
Tweak JS so Safari can choose admin actions

### DIFF
--- a/archivebox/templates/admin/base.html
+++ b/archivebox/templates/admin/base.html
@@ -197,7 +197,7 @@
 
                             // select the action button from the dropdown
                             container.find('select[name=action]')
-                                .find('op:selected').removeAttr('selected').end()
+                                .find('[selected]').removeAttr('selected').end()
                                 .find('[value=' + action_type + ']').attr('selected', 'selected').click()
                             
                             // click submit & replace the archivebox logo with a spinner


### PR DESCRIPTION
# Summary

This PR lets Safari use the admin actions.

I ran into #658 today. I noticed that Safari was submitting both the empty option and the selected options back to the server. Digging into it, I was able to get Safari to deselect the --------- option by using '[selected]' as the selector.

I am not a Safari expert.

# Related issues

#658

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
