### PR TITLE
(#847) Decode error output hints to string if needed

### DIFF
--- a/archivebox/logging_util.py
+++ b/archivebox/logging_util.py
@@ -432,7 +432,10 @@ def log_archive_method_finished(result: "ArchiveResult"):
         # Prettify error output hints string and limit to five lines
         hints = getattr(result.output, 'hints', None) or ()
         if hints:
-            hints = hints if isinstance(hints, (list, tuple)) else hints.split('\n')
+            if not isinstance(hints, (list, tuple)):
+                if isinstance(hints, bytes):
+                    hints = hints.decode()
+                hints = hints.split('\n')
             hints = (
                 '    {}{}{}'.format(ANSI['lightyellow'], line.strip(), ANSI['reset'])
                 for line in hints[:5] if line.strip()


### PR DESCRIPTION
# Summary

This decodes the error message hints from bytes into a str if needed so it can be split.

# Related issues

Fixes #847 

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
