### PR TITLE
Fix #725 - correctly parse tags on json import

### DIFF
--- a/archivebox/index/sql.py
+++ b/archivebox/index/sql.py
@@ -34,8 +34,11 @@ def write_link_to_sql_index(link: Link):
     from core.models import Snapshot, ArchiveResult
     info = {k: v for k, v in link._asdict().items() if k in Snapshot.keys}
     tags = info.pop("tags")
-    if tags is None:
-        tags = []
+
+    tag_set = (
+        set(tag.strip() for tag in (link.tags or '').split(','))
+    )
+    tag_list = list(tag_set) or []
 
     try:
         info["timestamp"] = Snapshot.objects.get(url=link.url).timestamp
@@ -44,7 +47,7 @@ def write_link_to_sql_index(link: Link):
             info["timestamp"] = str(float(info["timestamp"]) + 1.0)
 
         snapshot, _ = Snapshot.objects.update_or_create(url=link.url, defaults=info)
-    snapshot.save_tags(tags)
+    snapshot.save_tags(tag_list)
 
     for extractor, entries in link.history.items():
         for entry in entries:


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

This PR fixes #725 - instead of tags being split on each character, this fix mimics a code block further down in the same file to create a list of tags first before calling the ```save_tags()``` method.

https://github.com/ArchiveBox/ArchiveBox/blob/32764347ce2e59919f763c552bd3e250f49c2f5b/archivebox/index/sql.py#L107-L109 


# Related issues

#725 

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
