### PR TITLE
Added TAG_SEPARATOR_PATTERN option for splitting tags

### DIFF
--- a/archivebox/config.py
+++ b/archivebox/config.py
@@ -79,7 +79,7 @@ CONFIG_SCHEMA: Dict[str, ConfigDefaultDict] = {
         'URL_BLACKLIST':            {'type': str,   'default': r'\.(css|js|otf|ttf|woff|woff2|gstatic\.com|googleapis\.com/css)(\?.*)?$'},  # to avoid downloading code assets as their own pages
         'URL_WHITELIST':            {'type': str,   'default': None},
         'ENFORCE_ATOMIC_WRITES':    {'type': bool,  'default': True},
-        'TAG_SEPARATOR_PATTERN':    {'type': str,   'default': '[,]'},
+        'TAG_SEPARATOR_PATTERN':    {'type': str,   'default': r'[,]'},
     },
 
     'SERVER_CONFIG': {

--- a/archivebox/config.py
+++ b/archivebox/config.py
@@ -79,7 +79,7 @@ CONFIG_SCHEMA: Dict[str, ConfigDefaultDict] = {
         'URL_BLACKLIST':            {'type': str,   'default': r'\.(css|js|otf|ttf|woff|woff2|gstatic\.com|googleapis\.com/css)(\?.*)?$'},  # to avoid downloading code assets as their own pages
         'URL_WHITELIST':            {'type': str,   'default': None},
         'ENFORCE_ATOMIC_WRITES':    {'type': bool,  'default': True},
-        'TAG_SEPARATORS':           {'type': str,   'default': '[,]'},
+        'TAG_SEPARATOR_PATTERN':    {'type': str,   'default': '[,]'},
     },
 
     'SERVER_CONFIG': {

--- a/archivebox/config.py
+++ b/archivebox/config.py
@@ -79,6 +79,7 @@ CONFIG_SCHEMA: Dict[str, ConfigDefaultDict] = {
         'URL_BLACKLIST':            {'type': str,   'default': r'\.(css|js|otf|ttf|woff|woff2|gstatic\.com|googleapis\.com/css)(\?.*)?$'},  # to avoid downloading code assets as their own pages
         'URL_WHITELIST':            {'type': str,   'default': None},
         'ENFORCE_ATOMIC_WRITES':    {'type': bool,  'default': True},
+        'TAG_SEPARATORS':           {'type': str,   'default': '[,]'},
     },
 
     'SERVER_CONFIG': {

--- a/archivebox/config_stubs.py
+++ b/archivebox/config_stubs.py
@@ -98,7 +98,7 @@ class ConfigDict(BaseConfig, total=False):
     WGET_ARGS: List[str]
     CURL_ARGS: List[str]
     GIT_ARGS: List[str]
-    TAG_SEPARATORS: str
+    TAG_SEPARATOR_PATTERN: str
 
 
 ConfigDefaultValueGetter = Callable[[ConfigDict], ConfigValue]

--- a/archivebox/config_stubs.py
+++ b/archivebox/config_stubs.py
@@ -98,6 +98,7 @@ class ConfigDict(BaseConfig, total=False):
     WGET_ARGS: List[str]
     CURL_ARGS: List[str]
     GIT_ARGS: List[str]
+    TAG_SEPARATORS: str
 
 
 ConfigDefaultValueGetter = Callable[[ConfigDict], ConfigValue]

--- a/archivebox/index/sql.py
+++ b/archivebox/index/sql.py
@@ -12,7 +12,7 @@ from .schema import Link
 from ..util import enforce_types, parse_date
 from ..config import (
     OUTPUT_DIR,
-    TAG_SEPARATORS,
+    TAG_SEPARATOR_PATTERN,
 )
 
 
@@ -40,7 +40,7 @@ def write_link_to_sql_index(link: Link):
     info = {k: v for k, v in link._asdict().items() if k in Snapshot.keys}
 
     tag_list = list(dict.fromkeys(
-        tag.strip() for tag in re.split(TAG_SEPARATORS, link.tags or '')
+        tag.strip() for tag in re.split(TAG_SEPARATOR_PATTERN, link.tags or '')
     ))
     info.pop('tags')
 
@@ -112,7 +112,7 @@ def write_sql_link_details(link: Link, out_dir: Path=OUTPUT_DIR) -> None:
     snap.title = link.title
 
     tag_list = list(dict.fromkeys(
-        tag.strip() for tag in re.split(TAG_SEPARATORS, link.tags or '')
+        tag.strip() for tag in re.split(TAG_SEPARATOR_PATTERN, link.tags or '')
     ))
 
     snap.save()

--- a/archivebox/index/sql.py
+++ b/archivebox/index/sql.py
@@ -1,5 +1,7 @@
 __package__ = 'archivebox.index'
 
+import re
+
 from io import StringIO
 from pathlib import Path
 from typing import List, Tuple, Iterator
@@ -8,7 +10,10 @@ from django.db import transaction
 
 from .schema import Link
 from ..util import enforce_types, parse_date
-from ..config import OUTPUT_DIR
+from ..config import (
+    OUTPUT_DIR,
+    TAG_SEPARATORS,
+)
 
 
 ### Main Links Index
@@ -35,7 +40,7 @@ def write_link_to_sql_index(link: Link):
     info = {k: v for k, v in link._asdict().items() if k in Snapshot.keys}
 
     tag_list = list(dict.fromkeys(
-        tag.strip() for tag in (link.tags or '').split(',')
+        tag.strip() for tag in re.split(TAG_SEPARATORS, link.tags or '')
     ))
     info.pop('tags')
 
@@ -107,7 +112,7 @@ def write_sql_link_details(link: Link, out_dir: Path=OUTPUT_DIR) -> None:
     snap.title = link.title
 
     tag_list = list(dict.fromkeys(
-        tag.strip() for tag in (link.tags or '').split(',')
+        tag.strip() for tag in re.split(TAG_SEPARATORS, link.tags or '')
     ))
 
     snap.save()


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary
This PR adds the ```TAG_SEPARATOR_PATTERN``` option.  This option is a regex character class that will be used when splitting the tag string.
It defaults to ```[,]``` which will split tags on commas.  Splitting tags is currently done on commas so this will be backwards compatible and should not introduce breaking changes.

Some Examples:
* Splitting on spaces: ```TAG_SEPARATOR_PATTERN="[ ]"```
* Splitting on spaces and commas: ```TAG_SEPARATOR_PATTERN="[ ,]"```
* Splitting on spaces, commas, and semicolons: ```TAG_SEPARATOR_PATTERN="[ ,;]"```

---

* All previously passing tests still pass.
* I can give the Wiki text so that the Wiki page for the configuration can be updated with this new option.

<!--e.g. This PR fixes ABC or adds the ability to do XYZ...-->

# Related issues

#725 
<!-- e.g. #123 or Roadmap goal # https://github.com/pirate/ArchiveBox/wiki/Roadmap -->

# Changes these areas

- [ ] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [x] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
