### PR TITLE
typo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,5 +87,5 @@ services:
     #     ports:
     #         - 8080:8080
     #     volumes:
-    #         ./data:/archivebox
-    #         ./data/wayback:/webarchive
+    #         - ./data:/archivebox
+    #         - ./data/wayback:/webarchive


### PR DESCRIPTION
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.pywb.volumes contains an invalid type, it should be an array

<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

<!--e.g. This PR fixes ABC or adds the ability to do XYZ...-->

# Related issues

<!-- e.g. #123 or Roadmap goal # https://github.com/pirate/ArchiveBox/wiki/Roadmap -->

# Changes these areas

- [ ] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
