### PR TITLE
WIP: Add AppImage workflow

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,0 +1,76 @@
+name: Build AppImage
+
+on:
+  workflow_dispatch:
+  push:
+
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          fetch-depth: 1
+
+      - name: Install debian dependencies
+        run: |
+          sudo apt-get install -y \
+            python3.9             \
+            python3.9-venv        \
+            npm                   \
+            curl                  \
+            jq
+
+      - name: Download latest pkg2appimage release
+        run: |
+          set -x
+          cd appimage_dist
+          URL="$(curl -s https://api.github.com/repos/AppImage/pkg2appimage/releases/latest | jq -r '.assets | map(select( .name | test("^pkg2appimage-.*-x86_64.AppImage$")))[0] .browser_download_url')"
+          curl --location --output pkg2appimage "$URL"
+          chmod u+x pkg2appimage
+
+      - name: Build AppImage
+        run: |
+          set -x
+          export ARCHIVEBOXSRCDIR="$(pwd)"
+          cd appimage_dist
+          ARCH=x86_64 ./pkg2appimage archivebox.yml
+
+      - name: Archive build Appimage
+        uses: actions/upload-artifact@v2
+        with:
+          name: AppImage
+          path: appimage_dist/out
+
+      #- name: Add some links to test
+        #run: |
+          #mkdir data && cd data
+          #archivebox init
+          #archivebox add 'https://example.com'
+          #archivebox version
+          #archivebox status
+
+      # - name: Push build to PyPI
+      #   run: |
+      #     cd pip_dist/
+      #     python3 -m twine upload --repository testpypi pip_dist/*.{whl,tar.gz}
+      #     python3 -m twine upload --repository pypi pip_dist/*.{whl,tar.gz}
+
+      # - name: Commit built package
+      #   run: |
+      #     cd pip_dist/
+      #     git config --local user.email "action@github.com"
+      #     git config --local user.name "GitHub Action"
+      #     git commit -m "Pip package autobuild" -a
+      
+      # - name: Push build to Github
+      #   uses: ad-m/github-push-action@master
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     repository: ArchiveBox/pip-archivebox
+      #     branch: ${{ github.ref }}
+      #     directory: pip_dist
+

--- a/appimage_dist/archivebox.yml
+++ b/appimage_dist/archivebox.yml
@@ -1,0 +1,44 @@
+# Note: due to reasons, this requires a python3 (matching, e.g. python3.9 on both), python3-venv, nodejs and npm ON THE BUILDING HOST
+app: archivebox
+ingredients:
+  dist: focal
+  sources:
+    # Order is important, currently (as of 2022-01-23) apt-get.do-download in pkg2appimage prefers earlier sources
+    # When switching distributions, be sure to adapt the pythonpath in `script:` as well
+    - deb https://deb.nodesource.com/node_14.x focal main
+    - deb http://archive.ubuntu.com/ubuntu/ focal focal-updates focal-security main universe
+    - deb http://archive.ubuntu.com/ubuntu/ focal-updates main universe
+    - deb http://archive.ubuntu.com/ubuntu/ focal-security main universe
+  packages:
+    - python3.9-venv
+    - nodejs
+    - npm
+    - wget
+    - curl
+script:
+  - wget -c "https://raw.githubusercontent.com/ArchiveBox/ArchiveBox/dev/icon.png" -O archivebox.png
+  - cp ./archivebox.png ./usr/share/icons/hicolor/256x256/
+  - npm install -g --prefix ./usr 'git+https://github.com/pirate/readability-extractor'
+  - npm install -g --prefix ./usr '@postlight/mercury-parser'
+  - npm install -g --prefix ./usr 'gildas-lormeau/SingleFile#master'
+  - python3.9 -m venv usr
+  - source ./usr/bin/activate
+  - ./usr/bin/pip3 install --ignore-installed "$ARCHIVEBOXSRCDIR"
+  - cat > archivebox.desktop <<\EOF
+  - [Desktop Entry]
+  - Type=Application
+  - Terminal=true
+  - Name=archivebox
+  - Exec=archivebox
+  - Categories=Network;
+  - Icon=archivebox
+  - EOF
+  - usr/bin/pip3 freeze | grep "archivebox" | cut -d "=" -f 3 | head -n1 > ../VERSION
+  # Fixup the pythonpath: Warning: the import os happens some lines below
+  - sed -i '3s|^|import sys\nsys.path.insert(0, os.getenv("APPDIR") + "/usr/lib/python3.9/site-packages")\nsys.path.insert(0, os.getenv("APPDIR") + "/usr/lib/python3.9")\n|' ./usr/bin/archivebox
+  # Prepare it for "recursion", i.e. calling other python programms
+  - sed -i '3s|^|os.environ["PYTHONPATH"] = os.getenv("APPDIR") + "/usr/lib/python3.9:" + os.getenv("APPDIR") + "/usr/lib/python3.9/site-packages"\n|' ./usr/bin/archivebox
+  # Appimage chdirs to usr/ by default...
+  - sed -i '3s|^|import os\nos.chdir(os.getenv("OWD"))\n|' ./usr/bin/archivebox
+  # Patch python interpreter path
+  - find . -type f -exec sed -i '1 s|^#!/.*\.AppDir/usr/bin/\(python3*\)|#!/usr/bin/env \1|g' {} +


### PR DESCRIPTION
# Summary

As discussed in #916, I see value in a release of ArchiveBox as an AppImage along with the other releases.
Therefore, this commit adds a github workflow for automatically building an AppImage on pushes.

Please consider this PR as work in progress. The AppImage building works, but I'm not 100% sure as to how you wish to exactly integrate this workflow into the repository and how uploading to the releases page works. Currently, the AppImage is uploaded as an artifact of the CI-run to show that working artifacts are produced. Currently, you seem to have factored out all distribution-methods into their own submodules. Should I do the same for the appimage_dist?

Furthermore, I plan to write a short bit of documentation on the specifics of the AppImage (i.e.: what is packaged, what is not, that there is no sandboxing and that other distribution methods are preferred and potentially better supported). I'd probably put that into `docs/Install.md`. Does that sound like the correct location?

Any other comments/requests/*?

Thanks for your efforts!

# Related issues

#916

<!-- e.g. #123 or Roadmap goal # https://github.com/pirate/ArchiveBox/wiki/Roadmap -->

# Changes these areas

- [ ] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
