### PR TITLE
Add PikaPods as commercial hosting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ None of these hosting providers are officially endorsed:<br/>
 <sub><i>(most still require manual setup or manual periodic updating using the methods above)</i></sub>
 <br/><br/>
 <li><a href="https://www.stellarhosted.com/archivebox/"><img src="https://img.shields.io/badge/Semi_Managed_Hosting-StellarHosted.com-%23193f7e.svg?style=flat" height="22px"/></a> (USD $29-250/mo, <a href="https://www.stellarhosted.com/archivebox/#pricing">pricing</a>)</li>
+<li><a href="https://www.pikapods.com/pods?run=archivebox"><img src="https://img.shields.io/badge/Semi_Managed_Hosting-PikaPods.com-%2343a047.svg?style=flat" height="22px"/></a> (from USD $2.6/mo)</li>
 <li><a href="https://m.do.co/c/cbc4c0c17840">
  <img src="https://img.shields.io/badge/Unmanaged_VPS-DigitalOcean.com-%232f7cf7.svg?style=flat" height="22px"/>
 </a> (USD $5-50+/mo, <a href="https://m.do.co/c/cbc4c0c17840">🎗&nbsp; referral link</a>, <a href="https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-compose-on-ubuntu-20-04">instructions</a>)</li>


### PR DESCRIPTION
# Summary
This adds [PikaPods.com](https://www.pikapods.com/) as additional hosting option.

About PikaPods: Aims to make great open source apps, like ArchiveBox more accessible and easier to get started with. We already offer ArchiveBox in our “app store” and currently host around 30 instances.

So I'm suggesting to add PikaPods as additional install option. This would help an even wider audience to benefit from the project.

# Changes these areas

- [x] README

[Rendered preview](https://github.com/m3nu/ArchiveBox/tree/misc/add-pikapods-hosting#-other-options)