### PR TITLE
Fix Issue with Parenthesis in URL

### DIFF
--- a/archivebox/util.py
+++ b/archivebox/util.py
@@ -61,7 +61,7 @@ URL_REGEX = re.compile(
     r'(?:[a-zA-Z]|[0-9]'              # followed by allowed alphanum characters
     r'|[$-_@.&+]|[!*\(\),]'           #    or allowed symbols
     r'|(?:%[0-9a-fA-F][0-9a-fA-F]))'  #    or allowed unicode bytes
-    r'[^\]\[\(\)<>"\'\s]+'          # stop parsing at these symbols
+    r'[^\]\[<>"\'\s]+'                # stop parsing at these symbols
     r'))',
     re.IGNORECASE,
 )


### PR DESCRIPTION
# SUmmary

This commit fix an issue when one user try to add an URL
containing an URL. The pattern matching stop at the open
parenthesis. The URL generated is wrong and it archives
a truncated one.

You can easily reproduce this behavior by adding any URL
to archive and see this will not correctly archived.

# Related issues

Did not find any related issue.

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
