### PR TITLE
Attempted to warn on #984 and #1014

### DIFF
--- a/archivebox/extractors/__init__.py
+++ b/archivebox/extractors/__init__.py
@@ -7,6 +7,7 @@ from typing import Optional, List, Iterable, Union
 from datetime import datetime, timezone
 from django.db.models import QuerySet
 
+from ..core.settings import ERROR_LOG
 from ..index.schema import Link
 from ..index.sql import write_link_to_sql_index
 from ..index import (
@@ -127,10 +128,25 @@ def archive_link(link: Link, overwrite: bool=False, methods: Optional[Iterable[s
                     # print('{black}      X {}{reset}'.format(method_name, **ANSI))
                     stats['skipped'] += 1
             except Exception as e:
+                # Disabled until https://github.com/ArchiveBox/ArchiveBox/issues/984
+                # and https://github.com/ArchiveBox/ArchiveBox/issues/1014
+                # are fixed.
+                """
                 raise Exception('Exception in archive_methods.save_{}(Link(url={}))'.format(
                     method_name,
                     link.url,
                 )) from e
+                """
+		        # Instead, use the kludgy workaround from
+                # https://github.com/ArchiveBox/ArchiveBox/issues/984#issuecomment-1150541627
+                with open(ERROR_LOG, "a", encoding='utf-8') as f:
+                    command = ' '.join(sys.argv)
+                    ts = datetime.now(timezone.utc).strftime('%Y-%m-%d__%H:%M:%S')
+                    f.write(("\n" + 'Exception in archive_methods.save_{}(Link(url={}))'.format(
+                        method_name,
+                        link.url,
+                    ) + "\n"))
+                    #f.write(f"\n> {command}; ts={ts} version={config['VERSION']} docker={config['IN_DOCKER']} is_tty={config['IS_TTY']}\n")
 
         # print('    ', stats)
 


### PR DESCRIPTION
# Summary

This is a kludgy workaround that "what we can do for now is just add an exception catcher that skips trying to index those files if they throw encoding errors + display a warning like (> Warning: Skipped adding some files to full-text index as they are not in UTF-8 format)."

# Related issues

https://github.com/ArchiveBox/ArchiveBox/issues/984

https://github.com/ArchiveBox/ArchiveBox/issues/1014

Adapted from https://github.com/ArchiveBox/ArchiveBox/issues/984#issuecomment-1150541627

since this bug is a showstopper for me as well as @jgoerzen

# Changes these areas

- [X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk

# Notes

Ideally, we would have a conf config that disables or enables hard stop on UTF8 error.

I don't understand archivebox well enough to know that if, my workaround gets halfway through, and then we get archivebox > 0.6.3 and it fixes this bug, it will complete the rest of the pipeline.
