### PR TITLE
Add github markdown table-of-contents to README.md (automatically)

### DIFF
--- a/.github/workflows/gh-md-toc.yml
+++ b/.github/workflows/gh-md-toc.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches: [main]
+    paths: ['README.md']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          curl https://raw.githubusercontent.com/ekalinin/github-markdown-toc/0.8.0/gh-md-toc -o gh-md-toc
+          chmod a+x gh-md-toc
+          ./gh-md-toc --insert --no-backup --hide-footer foo.md
+          rm gh-md-toc
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Auto update markdown TOC

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ data1/
 data2/
 data3/
 output/
+
+# vim
+*.sw?

--- a/README.md
+++ b/README.md
@@ -414,6 +414,9 @@ ls ./archive/*/index.html  # or inspect snapshots on the filesystem
 
 <br/>
 
+<!--ts-->
+<!--te-->
+
 # Overview
 
 ## Input Formats


### PR DESCRIPTION
# Summary

Use [github-markdown-toc](https://github.com/ekalinin/github-markdown-toc) to add a TOC to the README.md as a git action.

# Related issues

https://github.com/ArchiveBox/ArchiveBox/pull/1023 made me realize that a lot of the docs are in the `README.md` so a TOC would be useful.

# Changes these areas

- [ ] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
- [x] Documentation

# Comments

* I understand this is an aesthetic choice, so feel free to close if you don't like.
* Since I am a new contributer, I can't actually check github actions on my PRs until maintainer gives me access :(
* The `curl` command in `https://raw.githubusercontent.com/ekalinin/github-markdown-toc/0.8.0/gh-md-toc -o gh-md-toc` makes me a little anxious but a) it's just in the CI and b) archivebox pulls a lot of submodules that are not authored by the team.
* I tried this [NPM toc](https://github.com/jonschlinkert/markdown-toc) but it added a ton of npm deps, some marked as insecure, and I couldn't get the command line to work after install.
