### PR TITLE
Add resnapshot option to `add` and `schedule` functions

### DIFF
--- a/archivebox/cli/archivebox_add.py
+++ b/archivebox/cli/archivebox_add.py
@@ -75,6 +75,12 @@ def main(args: Optional[List[str]]=None, stdin: Optional[IO]=None, pwd: Optional
         help="Re-archive URLs from scratch, overwriting any existing files"
     )
     parser.add_argument(
+        "--resnapshot",
+        default=False,
+        action="store_true",
+        help="Re-archive URLs from scratch, creating a new snapshot timestamped with the current time"
+    )
+    parser.add_argument(
         "--init", #'-i',
         action='store_true',
         help="Init/upgrade the curent data directory before adding",
@@ -114,6 +120,7 @@ def main(args: Optional[List[str]]=None, stdin: Optional[IO]=None, pwd: Optional
         update_all=command.update_all,
         index_only=command.index_only,
         overwrite=command.overwrite,
+        resnapshot=command.resnapshot,
         init=command.init,
         extractors=command.extract,
         parser=command.parser,

--- a/archivebox/cli/archivebox_schedule.py
+++ b/archivebox/cli/archivebox_schedule.py
@@ -52,6 +52,12 @@ def main(args: Optional[List[str]]=None, stdin: Optional[IO]=None, pwd: Optional
         help='Re-archive any URLs that have been previously archived, overwriting existing Snapshots',
     )
     parser.add_argument(
+        "--resnapshot",
+        default=False,
+        action="store_true",
+        help="Re-archive URLs from scratch, creating a new snapshot timestamped with the current time"
+    )
+    parser.add_argument(
         '--update',
         action='store_true',
         help='Re-pull any URLs that have been previously added, as needed to fill missing ArchiveResults',
@@ -99,6 +105,7 @@ def main(args: Optional[List[str]]=None, stdin: Optional[IO]=None, pwd: Optional
         every=command.every,
         depth=command.depth,
         overwrite=command.overwrite,
+        resnapshot=command.resnapshot,
         update=command.update,
         import_path=command.import_path,
         out_dir=pwd or OUTPUT_DIR,

--- a/archivebox/index/__init__.py
+++ b/archivebox/index/__init__.py
@@ -132,6 +132,17 @@ def validate_links(links: Iterable[Link]) -> List[Link]:
 
     return list(links)
 
+
+@enforce_types
+def add_timestamp_to_links(links: Iterable[Link], timestamp: Optional[str]=None) -> List[Link]:
+    """ Also overwrites any previous timestamps if there was one """
+    if timestamp is None:
+        timestamp = datetime.now(timezone.utc).isoformat('T', 'seconds')
+
+    links = [link.overwrite(url=link.url.split('#')[0] + f'#{timestamp}') for link in links]
+
+    return links
+
 @enforce_types
 def archivable_links(links: Iterable[Link]) -> Iterable[Link]:
     """remove chrome://, about:// or other schemed links that cant be archived"""


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

This PR adds a `--resnapshot` flag to the `add` and `schedule` functions so that one can re-snapshot from the CLI.
 - Added `add_timestamp_to_links` to `archivebox.index.__init__` which timestamps the url in the same way as `resnapshot_snapshot`

# Related issues

As discussed in https://github.com/ArchiveBox/ArchiveBox/issues/179
<!-- e.g. #123 or Roadmap goal # https://github.com/pirate/ArchiveBox/wiki/Roadmap -->

# Changes these areas

- [ ] Bugfixes
- [x] Feature behavior
- [x] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
