### PR TITLE
add CHROME_TIMEOUT args

### DIFF
--- a/archivebox/config.py
+++ b/archivebox/config.py
@@ -139,6 +139,7 @@ CONFIG_SCHEMA: Dict[str, ConfigDefaultDict] = {
         'COOKIES_FILE':             {'type': str,   'default': None},
         'CHROME_USER_DATA_DIR':     {'type': str,   'default': None},
 
+        'CHROME_TIMEOUT':           {'type': int,  'default': 0},
         'CHROME_HEADLESS':          {'type': bool,  'default': True},
         'CHROME_SANDBOX':           {'type': bool,  'default': lambda c: not c['IN_DOCKER']},
         'YOUTUBEDL_ARGS':           {'type': list,  'default': lambda c: [
@@ -981,6 +982,7 @@ def get_chrome_info(config: ConfigDict) -> ConfigValue:
         'RESOLUTION': config['RESOLUTION'],
         'CHECK_SSL_VALIDITY': config['CHECK_SSL_VALIDITY'],
         'CHROME_BINARY': bin_path(config['CHROME_BINARY']),
+        'CHROME_TIMEOUT':config['CHROME_TIMEOUT'],
         'CHROME_HEADLESS': config['CHROME_HEADLESS'],
         'CHROME_SANDBOX': config['CHROME_SANDBOX'],
         'CHROME_USER_AGENT': config['CHROME_USER_AGENT'],

--- a/archivebox/config.py
+++ b/archivebox/config.py
@@ -139,7 +139,7 @@ CONFIG_SCHEMA: Dict[str, ConfigDefaultDict] = {
         'COOKIES_FILE':             {'type': str,   'default': None},
         'CHROME_USER_DATA_DIR':     {'type': str,   'default': None},
 
-        'CHROME_TIMEOUT':           {'type': int,  'default': 0},
+        'CHROME_TIMEOUT':           {'type': int,   'default': 0},
         'CHROME_HEADLESS':          {'type': bool,  'default': True},
         'CHROME_SANDBOX':           {'type': bool,  'default': lambda c: not c['IN_DOCKER']},
         'YOUTUBEDL_ARGS':           {'type': list,  'default': lambda c: [
@@ -982,7 +982,7 @@ def get_chrome_info(config: ConfigDict) -> ConfigValue:
         'RESOLUTION': config['RESOLUTION'],
         'CHECK_SSL_VALIDITY': config['CHECK_SSL_VALIDITY'],
         'CHROME_BINARY': bin_path(config['CHROME_BINARY']),
-        'CHROME_TIMEOUT':config['CHROME_TIMEOUT'],
+        'CHROME_TIMEOUT': config['CHROME_TIMEOUT'],
         'CHROME_HEADLESS': config['CHROME_HEADLESS'],
         'CHROME_SANDBOX': config['CHROME_SANDBOX'],
         'CHROME_USER_AGENT': config['CHROME_USER_AGENT'],

--- a/archivebox/config_stubs.py
+++ b/archivebox/config_stubs.py
@@ -74,6 +74,7 @@ class ConfigDict(BaseConfig, total=False):
     CHROME_USER_AGENT: str
     COOKIES_FILE: Union[str, Path, None]
     CHROME_USER_DATA_DIR: Union[str, Path, None]
+    CHROME_TIMEOUT: int
     CHROME_HEADLESS: bool
     CHROME_SANDBOX: bool
 

--- a/archivebox/extractors/dom.py
+++ b/archivebox/extractors/dom.py
@@ -39,7 +39,7 @@ def save_dom(link: Link, out_dir: Optional[Path]=None, timeout: int=TIMEOUT) -> 
     output: ArchiveOutput = 'output.html'
     output_path = out_dir / output
     cmd = [
-        *chrome_args(TIMEOUT=timeout),
+        *chrome_args(),
         '--dump-dom',
         link.url
     ]

--- a/archivebox/extractors/pdf.py
+++ b/archivebox/extractors/pdf.py
@@ -37,7 +37,7 @@ def save_pdf(link: Link, out_dir: Optional[Path]=None, timeout: int=TIMEOUT) -> 
     out_dir = out_dir or Path(link.link_dir)
     output: ArchiveOutput = 'output.pdf'
     cmd = [
-        *chrome_args(TIMEOUT=timeout),
+        *chrome_args(),
         '--print-to-pdf',
         link.url,
     ]

--- a/archivebox/extractors/screenshot.py
+++ b/archivebox/extractors/screenshot.py
@@ -37,7 +37,7 @@ def save_screenshot(link: Link, out_dir: Optional[Path]=None, timeout: int=TIMEO
     out_dir = out_dir or Path(link.link_dir)
     output: ArchiveOutput = 'screenshot.png'
     cmd = [
-        *chrome_args(TIMEOUT=timeout),
+        *chrome_args(),
         '--screenshot',
         link.url,
     ]

--- a/archivebox/extractors/singlefile.py
+++ b/archivebox/extractors/singlefile.py
@@ -42,7 +42,7 @@ def save_singlefile(link: Link, out_dir: Optional[Path]=None, timeout: int=TIMEO
     out_dir = out_dir or Path(link.link_dir)
     output = "singlefile.html"
 
-    browser_args = chrome_args(TIMEOUT=0)
+    browser_args = chrome_args(CHROME_TIMEOUT=0)
 
     # SingleFile CLI Docs: https://github.com/gildas-lormeau/SingleFile/tree/master/cli
     browser_args = '--browser-args={}'.format(json.dumps(browser_args[1:]))

--- a/archivebox/util.py
+++ b/archivebox/util.py
@@ -260,8 +260,8 @@ def chrome_args(**options) -> List[str]:
     if options['RESOLUTION']:
         cmd_args += ('--window-size={}'.format(options['RESOLUTION']),)
 
-    #if options['TIMEOUT']:
-    #    cmd_args += ('--timeout={}'.format(options['TIMEOUT'] * 1000),)
+    if options['CHROME_TIMEOUT']:
+       cmd_args += ('--timeout={}'.format(options['CHROME_TIMEOUT'] * 1000),)
 
     if options['CHROME_USER_DATA_DIR']:
         cmd_args.append('--user-data-dir={}'.format(options['CHROME_USER_DATA_DIR']))


### PR DESCRIPTION
# Summary

- add `CHROME_TIMEOUT` args

# Environment

`Chromium 111.0.5563.64 snap`

# Why

Chromium `--timeout` argument doesn't actually do timeout behavior.
For example, when `--screenshot` argument is given, it delays the shooting for the time specified by the timeout.
Not sure if this behavior is caused by chromium v111.

# Note

CHROME_TIMEOUT is set to 0 by default.
For example, when `--screenshot` argument is given, If timeout is set to 0, the image is captured at the same time DOMContentLoaded fires, so some Web sites may not be captured as intended.
When set to 1 or higher, the possibility of getting the desired photo increases dramatically.

# Related

https://github.com/ArchiveBox/ArchiveBox/commit/606fa397a42e2821d8879b6274e056c8f75ccbe0

# Changes these areas

- [x] Bugfixes
- [x] Feature behavior
- [ ] Command line interface
- [x] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
