### PR TITLE
Add missing closing quote to style attribute

### DIFF
--- a/archivebox/templates/core/index_row.html
+++ b/archivebox/templates/core/index_row.html
@@ -36,7 +36,7 @@
             {% endif %}
         </span>
     </td>
-    <td style="text-align:left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; title="{{link.url}}">
+    <td style="text-align:left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;" title="{{link.url}}">
         <a href="{{link.url}}">
             {{link.url}}
         </a>


### PR DESCRIPTION
# Summary

This PR fixes the markup in the index_row.html template by closing the quote of a `style` attribute.  Its absence became apparent when I archived a URL with a trailing equals sign, breaking the layout of the table.

# Related issues

None I know of.

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
