### PR TITLE
Fix for Issue #1008

### DIFF
--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -962,7 +962,7 @@ def setup(out_dir: Path=OUTPUT_DIR) -> None:
                 PYTHON_BINARY, '-m', 'pip',
                 'show',
                 'youtube_dl',
-            ], capture_output=True, text=True, cwd=out_dir).stdout.split('Location: ')[-1].split('\n', 1)[0]
+            ], capture_output=True, text=True, cwd=out_dir).stdout.decode().split('Location: ')[-1].split('\n', 1)[0]
             NEW_YOUTUBEDL_BINARY = Path(pkg_path) / 'youtube_dl' / '__main__.py'
             os.chmod(NEW_YOUTUBEDL_BINARY, 0o777)
             assert NEW_YOUTUBEDL_BINARY.exists(), f'youtube_dl must exist inside {pkg_path}'


### PR DESCRIPTION
- Added missing decode() when setting pkg_path variable

# Summary
This PR fixed the missing decode() function call when ArchiveBox attempts to set pkg_path during install of the youtube-dl library.

# Related issues
https://github.com/ArchiveBox/ArchiveBox/issues/1008

# Changes these areas

- [X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
