### PR TITLE
Add FAVICON_PROVIDER option for custom favicon service

### DIFF
--- a/archivebox/config.py
+++ b/archivebox/config.py
@@ -183,7 +183,8 @@ CONFIG_SCHEMA: Dict[str, ConfigDefaultDict] = {
                                                                 '--compressed'
                                                                ]},
         'GIT_ARGS':                 {'type': list,  'default': ['--recursive']},
-        'SINGLEFILE_ARGS':          {'type': list,  'default' : None}
+        'SINGLEFILE_ARGS':          {'type': list,  'default' : None},
+        'FAVICON_PROVIDER':         {'type': str,   'default': 'https://www.google.com/s2/favicons?domain={}'},
     },
 
     'SEARCH_BACKEND_CONFIG' : {

--- a/archivebox/extractors/favicon.py
+++ b/archivebox/extractors/favicon.py
@@ -10,6 +10,7 @@ from ..util import enforce_types, domain
 from ..config import (
     TIMEOUT,
     SAVE_FAVICON,
+    FAVICON_PROVIDER,
     CURL_BINARY,
     CURL_ARGS,
     CURL_VERSION,
@@ -40,7 +41,7 @@ def save_favicon(link: Link, out_dir: Optional[Path]=None, timeout: int=TIMEOUT)
         '--output', str(output),
         *(['--user-agent', '{}'.format(CURL_USER_AGENT)] if CURL_USER_AGENT else []),
         *([] if CHECK_SSL_VALIDITY else ['--insecure']),
-        'https://www.google.com/s2/favicons?domain={}'.format(domain(link.url)),
+        FAVICON_PROVIDER.format(domain(link.url)),
     ]
     status = 'failed'
     timer = TimedProgress(timeout, prefix='      ')

--- a/archivebox/index/schema.py
+++ b/archivebox/index/schema.py
@@ -20,7 +20,7 @@ from django.utils.functional import cached_property
 
 from ..system import get_dir_size
 from ..util import ts_to_date_str, parse_date
-from ..config import OUTPUT_DIR, ARCHIVE_DIR_NAME
+from ..config import OUTPUT_DIR, ARCHIVE_DIR_NAME, FAVICON_PROVIDER
 
 class ArchiveError(Exception):
     def __init__(self, message, hints=None):
@@ -423,7 +423,7 @@ class Link:
         canonical = {
             'index_path': 'index.html',
             'favicon_path': 'favicon.ico',
-            'google_favicon_path': 'https://www.google.com/s2/favicons?domain={}'.format(self.domain),
+            'google_favicon_path': FAVICON_PROVIDER.format(self.domain),
             'wget_path': wget_output_path(self),
             'warc_path': 'warc/',
             'singlefile_path': 'singlefile.html',


### PR DESCRIPTION
# Summary

Add `FAVICON_PROVIDER` option to allow configuring any favicon service.

Tested with [The Favicon Finder](https://besticon-demo.herokuapp.com/) (a demo deployment of [mat/besticon](https://github.com/mat/besticon) mentioned in the related issue), and also with [Favicon Kit](faviconkit.com).

e.g.

```sh
archivebox config --set FAVICON_PROVIDER='https://besticon-demo.herokuapp.com/icon?url={}&size=32..64..64'
```

# Questions

I noticed that the Google URL was hard-coded in two places: `archivebox/extractors/favicon.py` and `archivebox/index/schema.py`. I made changes in both, but I'm not sure if I should have done the latter -- the top of that file says not to add any more features to the file. Is it better to leave it as is, with the old hard-coded Google URL, or change it?

# Related issues

#1117

# Changes these areas

- [ ] Bugfixes
- [x] Feature behavior
- [ ] Command line interface
- [x] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
