### PR TITLE
Set /app permissions in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ RUN apt-get update -qq \
 # Install ArchiveBox Python package and its dependencies
 WORKDIR "$CODE_DIR"
 ADD . "$CODE_DIR"
-RUN pip install -e .
+RUN chown -R root:root . && chmod a+rX -R . && pip install -e .
 
 # Setup ArchiveBox runtime config
 WORKDIR "$DATA_DIR"

--- a/README.md
+++ b/README.md
@@ -913,6 +913,7 @@ docker run -it -p 8000:8000 \
     archivebox server 0.0.0.0:8000 --debug --reload
 
 # (remove the --reload flag and add the --nothreading flag when profiling with the django debug toolbar)
+# When using --reload, make sure any files you create can be read by the user in the Docker container, eg with 'chmod a+rX'.
 ```
 
 </details>


### PR DESCRIPTION
Set /app permissions in the Dockerfile, and add a note in readme to be careful of permissions with --reload.

# Summary

Under some conditions, building the Docker image will fail trying to run `archivebox version` because the user in Docker doesn't have permission to access the archivebox code which has been copied to `/app` in the container. This can happen if, for instance, you clone the git repo with a umask of 077 -- the user running in the container likely does not match the host user's UID, so the archivebox code is not readable.

This results in hard-to-understand errors like

```text
#25 [21/21] RUN /app/bin/docker_entrypoint.sh archivebox version
#25 sha256:71245cb735d1d262c964310fe85dcb7b811adfa9ba2402cdb7cf1c0a11af5950
#25 0.333 Traceback (most recent call last):
#25 0.333   File "/usr/local/bin/archivebox", line 33, in <module>
#25 0.333     sys.exit(load_entry_point('archivebox', 'console_scripts', 'archivebox')())
#25 0.333              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#25 0.333   File "/usr/local/bin/archivebox", line 25, in importlib_load_entry_point
#25 0.334     return next(matches).load()
#25 0.334            ^^^^^^^^^^^^^^^^^^^^
#25 0.334   File "/usr/local/lib/python3.11/importlib/metadata/__init__.py", line 202, in load
#25 0.334     module = import_module(match.group('module'))
#25 0.334              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#25 0.334   File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
#25 0.334     return _bootstrap._gcd_import(name[level:], package, level)
#25 0.335            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#25 0.335   File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
#25 0.335   File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
#25 0.335   File "<frozen importlib._bootstrap>", line 1142, in _find_and_load_unlocked
#25 0.335 ModuleNotFoundError: No module named 'archivebox.cli'
```

This PR changes ownership and permissions after copying the code to `/app`, which mostly solves this issue. I checked the `archivebox/archivebox:dev` container and found that `root` owned the files under `/app`, so that's what I did explicitly here. (Maybe CI is doing that automatically for the container pushed to Dockerhub?)

One development case where it might still cause problems is if you have a restrictive umask and create a file after the server is started with the `--reload` argument. I add a note to the readme to be careful with permissions in that case.

# Related issues

Fixes #978

In my testing, the only thing I needed was the permissions fix. (Like the reporter of that issue, my default umask is 077 and I ran into this myself.) I didn't need their change to `$PATH`.

# Questions before merging

* Is `root` the proper owner, and `022` the proper umask, for all files under `/app`?
* Any reason to keep the changes to `$PATH` from #978 ?

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
