### PR TITLE
fix: make oneshot command return successful exit code

### DIFF
--- a/archivebox/extractors/__init__.py
+++ b/archivebox/extractors/__init__.py
@@ -162,7 +162,7 @@ def archive_link(link: Link, overwrite: bool=False, methods: Optional[Iterable[s
 
         write_link_details(link, out_dir=out_dir, skip_sql_index=False)
 
-        log_link_archiving_finished(link, out_dir or link.link_dir, is_new, stats, start_ts)
+        log_link_archiving_finished(link, out_dir, is_new, stats, start_ts)
 
     except KeyboardInterrupt:
         try:

--- a/archivebox/extractors/__init__.py
+++ b/archivebox/extractors/__init__.py
@@ -162,7 +162,7 @@ def archive_link(link: Link, overwrite: bool=False, methods: Optional[Iterable[s
 
         write_link_details(link, out_dir=out_dir, skip_sql_index=False)
 
-        log_link_archiving_finished(link, link.link_dir, is_new, stats, start_ts)
+        log_link_archiving_finished(link, out_dir or link.link_dir, is_new, stats, start_ts)
 
     except KeyboardInterrupt:
         try:

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -25,4 +25,36 @@ def test_oneshot_command_saves_page_in_right_folder(tmp_path, disable_extractors
     assert "index.json" in items
     assert not "index.sqlite3" in current_path
     assert "output.html" in items
-    
+
+def test_oneshot_command_succeeds(tmp_path, disable_extractors_dict):
+    disable_extractors_dict.update({"SAVE_DOM": "true"})
+    process = subprocess.run(
+        [
+            "archivebox",
+            "oneshot",
+            f"--out-dir={tmp_path}",
+            "--extract=title,favicon,dom",
+            "http://127.0.0.1:8080/static/example.com.html",
+        ],
+        capture_output=True,
+        env=disable_extractors_dict,
+    )
+
+    assert process.returncode == 0
+
+def test_oneshot_command_logs_archiving_finished(tmp_path, disable_extractors_dict):
+    disable_extractors_dict.update({"SAVE_DOM": "true"})
+    process = subprocess.run(
+        [
+            "archivebox",
+            "oneshot",
+            f"--out-dir={tmp_path}",
+            "--extract=title,favicon,dom",
+            "http://127.0.0.1:8080/static/example.com.html",
+        ],
+        capture_output=True,
+        env=disable_extractors_dict,
+    )
+
+    output_str = process.stdout.decode("utf-8")
+    assert "4 files" in output_str


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

While the oneshot command correctly creates output files, the command itself returns an exit code, and logs the following error:
```
    ! Failed to archive link: FileNotFoundError: [Errno 2] No such file or directory: '<archivebox_location>/archive/1685300775.342935'
Traceback (most recent call last):
  File "/Users/sascha/dev/projects/linkding/venv/archivebox/bin/archivebox", line 8, in <module>
    sys.exit(main())
  File "/Users/sascha/dev/projects/linkding/venv/archivebox/lib/python3.10/site-packages/archivebox/cli/__init__.py", line 140, in main
    run_subcommand(
  File "/Users/sascha/dev/projects/linkding/venv/archivebox/lib/python3.10/site-packages/archivebox/cli/__init__.py", line 80, in run_subcommand
    module.main(args=subcommand_args, stdin=stdin, pwd=pwd)    # type: ignore
  File "/Users/sascha/dev/projects/linkding/venv/archivebox/lib/python3.10/site-packages/archivebox/cli/archivebox_oneshot.py", line 65, in main
    oneshot(
  File "/Users/sascha/dev/projects/linkding/venv/archivebox/lib/python3.10/site-packages/archivebox/util.py", line 114, in typechecked_function
    return func(*args, **kwargs)
  File "/Users/sascha/dev/projects/linkding/venv/archivebox/lib/python3.10/site-packages/archivebox/main.py", line 548, in oneshot
    archive_link(oneshot_link[0], out_dir=out_dir, methods=methods)
  File "/Users/sascha/dev/projects/linkding/venv/archivebox/lib/python3.10/site-packages/archivebox/util.py", line 114, in typechecked_function
    return func(*args, **kwargs)
  File "/Users/sascha/dev/projects/linkding/venv/archivebox/lib/python3.10/site-packages/archivebox/extractors/__init__.py", line 146, in archive_link
    log_link_archiving_finished(link, link.link_dir, is_new, stats, start_ts)
  File "/Users/sascha/dev/projects/linkding/venv/archivebox/lib/python3.10/site-packages/archivebox/logging_util.py", line 396, in log_link_archiving_finished
    size = get_dir_size(link_dir)
  File "/Users/sascha/dev/projects/linkding/venv/archivebox/lib/python3.10/site-packages/archivebox/util.py", line 114, in typechecked_function
    return func(*args, **kwargs)
  File "/Users/sascha/dev/projects/linkding/venv/archivebox/lib/python3.10/site-packages/archivebox/system.py", line 131, in get_dir_size
    for entry in os.scandir(path):
FileNotFoundError: [Errno 2] No such file or directory: '<archivebox_location>/archive/1685300775.342935'
```
It fails in the `log_link_archiving_finished` function, where it tries to log information about the link's directory within the archive, which doesn't exist because the oneshot command writes its output into a custom output dir.

This change updates the call to that function to alternatively pass the custom output dir if it has been specified.

I have seen an issue that mentions that the oneshot command is considered deprecated, still I would find it useful and this fix seems to have low impact.

# Related issues

No related issue.

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
