### PR TITLE
bin_version means to modify, not replace environ

### DIFF
--- a/archivebox/config.py
+++ b/archivebox/config.py
@@ -690,7 +690,8 @@ def bin_version(binary: Optional[str]) -> Optional[str]:
         return None
 
     try:
-        version_str = run([abspath, "--version"], stdout=PIPE, env={'LANG': 'C'}).stdout.strip().decode()
+        bin_env = os.environ | {'LANG': 'C'}
+        version_str = run([abspath, "--version"], stdout=PIPE, env=bin_env).stdout.strip().decode()
         if not version_str:
             version_str = run([abspath, "--version"], stdout=PIPE).stdout.strip().decode()
         # take first 3 columns of first line of version info


### PR DESCRIPTION
# Summary

The `bin_version` function means to modify the environment, not replace it entirely. Fixes bugs that occur when it wipes out the PATH environment variable, such as when running in a virtual environment. E.g. results in bin_version not being able to invoke `node` when it exists on the `PATH`.

<!--e.g. This PR fixes ABC or adds the ability to do XYZ...-->

# Related issues

*None*
<!-- e.g. #123 or Roadmap goal # https://github.com/pirate/ArchiveBox/wiki/Roadmap -->

# Changes these areas

- [X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
