### PR TITLE
Fix Wallabag Parser file access bug

### DIFF
--- a/archivebox/parsers/__init__.py
+++ b/archivebox/parsers/__init__.py
@@ -149,17 +149,7 @@ def run_parser_functions(to_parse: IO[str], timer, root_url: Optional[str]=None,
 def save_text_as_source(raw_text: str, filename: str='{ts}-stdin.txt', out_dir: Path=OUTPUT_DIR) -> str:
     ts = str(datetime.now(timezone.utc).timestamp()).split('.', 1)[0]
     source_path = str(out_dir / SOURCES_DIR_NAME / filename.format(ts=ts))
-
-    referenced_texts = ''
-
-    for entry in raw_text.split():
-        try:
-            if Path(entry).exists():
-                referenced_texts += Path(entry).read_text()
-        except Exception as err:
-            print(err)
-
-    atomic_write(source_path, raw_text + '\n' + referenced_texts)
+    atomic_write(source_path, raw_text)
     log_source_saved(source_file=source_path)
     return source_path
 


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

In this PR I attempt to debug https://github.com/ArchiveBox/ArchiveBox/issues/1000.

# Related issues

- Wallabag importing was fixed: https://github.com/ArchiveBox/ArchiveBox/issues/971

# Changes these areas

- [x] Temporary Workaround: Don't attempt to access filesystem in https://github.com/peterrus/ArchiveBox/blob/5b7efe256658dc30892a1d7f5c6d86a5b5ef0bc5/archivebox/parsers/__init__.py#L149
