### PR TITLE
Fix HTML title parsing bugs.

### DIFF
--- a/archivebox/extractors/title.py
+++ b/archivebox/extractors/title.py
@@ -26,7 +26,7 @@ from ..logging_util import TimedProgress
 
 HTML_TITLE_REGEX = re.compile(
     r'<title.*?>'                      # start matching text after <title> tag
-    r'(.[^<>]+)',                      # get everything up to these symbols
+    r'([^<>]+)',                      # get everything up to these symbols
     re.IGNORECASE | re.MULTILINE | re.DOTALL | re.UNICODE,
 )
 


### PR DESCRIPTION

<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

<!--e.g. This PR fixes ABC or adds the ability to do XYZ...-->
This slightly modifies the `HTML_TITLE_REGEX` and fixes two parsing errors. The first occurred when title tags were empty (e.g. `<title></title>`) which was parsed as `</title`. The second occurred when titles were a single character (e.g. `<title>A</title>`) which was not matched by the regex, and so the title would fall back to `link.base_url`.

With this change, now when tags are empty, the title falls back to `link.base_url`, and single character titles are parsed correctly.

I tested the new regex with the edge cases I could think of, and found some malformed HTML will still lead to undesired behavior. A more robust regex could probably be used in the future.

# Related issues

<!-- e.g. #123 or Roadmap goal # https://github.com/pirate/ArchiveBox/wiki/Roadmap -->
#1222 

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
