### PR TITLE
Add config options to initialize admin user on first run without prompting

### DIFF
--- a/archivebox/config.py
+++ b/archivebox/config.py
@@ -91,8 +91,8 @@ CONFIG_SCHEMA: Dict[str, ConfigDefaultDict] = {
         'OUTPUT_PERMISSIONS':       {'type': str,   'default': '644'},
         'RESTRICT_FILE_NAMES':      {'type': str,   'default': 'windows'},
         'URL_BLACKLIST':            {'type': str,   'default': r'\.(css|js|otf|ttf|woff|woff2|gstatic\.com|googleapis\.com/css)(\?.*)?$'},  # to avoid downloading code assets as their own pages
-        'ARCHIVEBOX_USERNAME':      {'type': str,   'default': None},
-        'ARCHIVEBOX_PASSWORD':      {'type': str,   'default': None},
+        'ADMIN_USERNAME':      {'type': str,   'default': None},
+        'ADMIN_PASSWORD':      {'type': str,   'default': None},
         'URL_WHITELIST':            {'type': str,   'default': None},
         'ENFORCE_ATOMIC_WRITES':    {'type': bool,  'default': True},
         'TAG_SEPARATOR_PATTERN':    {'type': str,   'default': r'[,]'},

--- a/archivebox/config.py
+++ b/archivebox/config.py
@@ -91,8 +91,8 @@ CONFIG_SCHEMA: Dict[str, ConfigDefaultDict] = {
         'OUTPUT_PERMISSIONS':       {'type': str,   'default': '644'},
         'RESTRICT_FILE_NAMES':      {'type': str,   'default': 'windows'},
         'URL_BLACKLIST':            {'type': str,   'default': r'\.(css|js|otf|ttf|woff|woff2|gstatic\.com|googleapis\.com/css)(\?.*)?$'},  # to avoid downloading code assets as their own pages
-        'ADMIN_USERNAME':      {'type': str,   'default': None},
-        'ADMIN_PASSWORD':      {'type': str,   'default': None},
+        'ADMIN_USERNAME':           {'type': str,   'default': None},
+        'ADMIN_PASSWORD':           {'type': str,   'default': None},
         'URL_WHITELIST':            {'type': str,   'default': None},
         'ENFORCE_ATOMIC_WRITES':    {'type': bool,  'default': True},
         'TAG_SEPARATOR_PATTERN':    {'type': str,   'default': r'[,]'},

--- a/archivebox/config.py
+++ b/archivebox/config.py
@@ -91,6 +91,8 @@ CONFIG_SCHEMA: Dict[str, ConfigDefaultDict] = {
         'OUTPUT_PERMISSIONS':       {'type': str,   'default': '644'},
         'RESTRICT_FILE_NAMES':      {'type': str,   'default': 'windows'},
         'URL_BLACKLIST':            {'type': str,   'default': r'\.(css|js|otf|ttf|woff|woff2|gstatic\.com|googleapis\.com/css)(\?.*)?$'},  # to avoid downloading code assets as their own pages
+        'ARCHIVEBOX_USERNAME':      {'type': str,   'default': None},
+        'ARCHIVEBOX_PASSWORD':      {'type': str,   'default': None},
         'URL_WHITELIST':            {'type': str,   'default': None},
         'ENFORCE_ATOMIC_WRITES':    {'type': bool,  'default': True},
         'TAG_SEPARATOR_PATTERN':    {'type': str,   'default': r'[,]'},

--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -425,8 +425,8 @@ def init(force: bool=False, quick: bool=False, setup: bool=False, out_dir: Path=
     from django.contrib.auth.models import User
 
     if (ADMIN_USERNAME and ADMIN_PASSWORD) and not User.objects.filter(username=ADMIN_USERNAME).exists():
-        User.objects.create_superuser(username=ADMIN_USERNAME, password=ADMIN_PASSWORD)
         print('{green}[+] Found ADMIN_USERNAME and ADMIN_PASSWORD configuration options, creating new admin user.{reset}'.format(**ANSI))
+        User.objects.create_superuser(username=ADMIN_USERNAME, password=ADMIN_PASSWORD)
 
     if existing_index:
         print('{green}[√] Done. Verified and updated the existing ArchiveBox collection.{reset}'.format(**ANSI))

--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -424,9 +424,9 @@ def init(force: bool=False, quick: bool=False, setup: bool=False, out_dir: Path=
 
     from django.contrib.auth.models import User
 
-    if (ADMIN_USERNAME and ADMIN_PASSWORD) and not User.objects.filter(username=ADMIN_USERNAME, is_superuser=True).exists():
+    if (ADMIN_USERNAME and ADMIN_PASSWORD) and not User.objects.filter(username=ADMIN_USERNAME).exists():
         User.objects.create_superuser(username=ADMIN_USERNAME, password=ADMIN_PASSWORD)
-        print('{green}[+] New ADMIN_USERNAME and  ADMIN_PASSWORD configuration options found. Creating new admin user.{reset}'.format(ADMIN_USERNAME, ADMIN_PASSWORD, **ANSI))
+        print('{green}[+] Found ADMIN_USERNAME and ADMIN_PASSWORD configuration options, creating new admin user.{reset}'.format(**ANSI))
 
     if existing_index:
         print('{green}[√] Done. Verified and updated the existing ArchiveBox collection.{reset}'.format(**ANSI))

--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -112,6 +112,8 @@ from .config import (
     load_all_config,
     CONFIG,
     USER_CONFIG,
+    ARCHIVEBOX_USERNAME,
+    ARCHIVEBOX_PASSWORD,
     get_real_name,
     setup_django,
 )
@@ -422,7 +424,10 @@ def init(force: bool=False, quick: bool=False, setup: bool=False, out_dir: Path=
     if existing_index:
         print('{green}[√] Done. Verified and updated the existing ArchiveBox collection.{reset}'.format(**ANSI))
     else:
-        # TODO: allow creating new supersuer via env vars on first init
+        if ARCHIVEBOX_USERNAME and ARCHIVEBOX_PASSWORD:
+            print('{green}[+] ARCHIVEBOX_USERNAME and  ARCHIVEBOX_PASSWORD configuration options found. Creating new admin user with username {} and password {}.{reset}'.format(ARCHIVEBOX_USERNAME, ARCHIVEBOX_PASSWORD, **ANSI))
+            from django.contrib.auth.models import User
+            User.objects.create_superuser(username=ARCHIVEBOX_USERNAME, password=ARCHIVEBOX_PASSWORD)
         # if config.HTTP_USER and config.HTTP_PASS:
         #     from django.contrib.auth.models import User
         #     User.objects.create_superuser(HTTP_USER, '', HTTP_PASS)

--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -425,7 +425,7 @@ def init(force: bool=False, quick: bool=False, setup: bool=False, out_dir: Path=
         print('{green}[√] Done. Verified and updated the existing ArchiveBox collection.{reset}'.format(**ANSI))
     else:
         if ARCHIVEBOX_USERNAME and ARCHIVEBOX_PASSWORD:
-            print('{green}[+] ARCHIVEBOX_USERNAME and  ARCHIVEBOX_PASSWORD configuration options found. Creating new admin user with username {} and password {}.{reset}'.format(ARCHIVEBOX_USERNAME, ARCHIVEBOX_PASSWORD, **ANSI))
+            print('{green}[+] ARCHIVEBOX_USERNAME and  ARCHIVEBOX_PASSWORD configuration options found. Creating new admin user.{reset}'.format(**ANSI))
             from django.contrib.auth.models import User
             User.objects.create_superuser(username=ARCHIVEBOX_USERNAME, password=ARCHIVEBOX_PASSWORD)
         # if config.HTTP_USER and config.HTTP_PASS:

--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -112,8 +112,8 @@ from .config import (
     load_all_config,
     CONFIG,
     USER_CONFIG,
-    ARCHIVEBOX_USERNAME,
-    ARCHIVEBOX_PASSWORD,
+    ADMIN_USERNAME,
+    ADMIN_PASSWORD,
     get_real_name,
     setup_django,
 )
@@ -421,17 +421,16 @@ def init(force: bool=False, quick: bool=False, setup: bool=False, out_dir: Path=
         write_main_index(list(pending_links.values()), out_dir=out_dir)
 
     print('\n{green}----------------------------------------------------------------------{reset}'.format(**ANSI))
+
+    from django.contrib.auth.models import User
+
+    if (ADMIN_USERNAME and ADMIN_PASSWORD) and not User.objects.filter(username=ADMIN_USERNAME, is_superuser=True).exists():
+        User.objects.create_superuser(username=ADMIN_USERNAME, password=ADMIN_PASSWORD)
+        print('{green}[+] New ADMIN_USERNAME and  ADMIN_PASSWORD configuration options found. Creating new admin user.{reset}'.format(ADMIN_USERNAME, ADMIN_PASSWORD, **ANSI))
+
     if existing_index:
         print('{green}[√] Done. Verified and updated the existing ArchiveBox collection.{reset}'.format(**ANSI))
     else:
-        if ARCHIVEBOX_USERNAME and ARCHIVEBOX_PASSWORD:
-            print('{green}[+] ARCHIVEBOX_USERNAME and  ARCHIVEBOX_PASSWORD configuration options found. Creating new admin user.{reset}'.format(**ANSI))
-            from django.contrib.auth.models import User
-            User.objects.create_superuser(username=ARCHIVEBOX_USERNAME, password=ARCHIVEBOX_PASSWORD)
-        # if config.HTTP_USER and config.HTTP_PASS:
-        #     from django.contrib.auth.models import User
-        #     User.objects.create_superuser(HTTP_USER, '', HTTP_PASS)
-
         print('{green}[√] Done. A new ArchiveBox collection was initialized ({} links).{reset}'.format(len(all_links) + len(pending_links), **ANSI))
 
     json_index = out_dir / JSON_INDEX_FILENAME


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary
This adds the option to create an admin user on initialization without prompting. The configuration options `ARCHIVEBOX_USERNAME` and `ARCHIVEBOX_PASSWORD` are only checked on first initialization (if there's no `index.sqlite3` file). The admin user is only created if both options are present.

I'm not sure if there are some other use cases that exist that are not covered by this implementation, please let me know if so.
<!--e.g. This PR fixes ABC or adds the ability to do XYZ...-->

# Related issues

<!-- e.g. #123 or Roadmap goal # https://github.com/pirate/ArchiveBox/wiki/Roadmap -->
#734 
# Changes these areas

- [ ] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [x] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
