### PR TITLE
Fix `python_tests`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-latest]
-        python: [3.7]
+        python: [3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,15 +24,18 @@ jobs:
 
       ### Setup Python & JS Languages
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
 
       - name: Set up Node JS 14.7.0
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.7.0
+          node-version: 18.12.0
+
+      - name: Setup PDM
+        uses: pdm-project/setup-pdm@v3
 
       ### Install Python & JS Dependencies
       - name: Get pip cache dir
@@ -53,7 +56,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel pytest bottle build
           ./bin/build_pip.sh
-          python -m pip install .
+          pdm install
 
       - name: Get npm cache dir
         id: npm-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install pip dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel pytest bottle
+          python -m pip install --upgrade pip setuptools wheel pytest bottle build
           ./bin/build_pip.sh
           python -m pip install .
 


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary
As seen in https://github.com/ArchiveBox/ArchiveBox/actions/runs/6639096893/job/18036765296 `python_tests` didn't run `pytest`.
Now it at least run on x64 Ubuntu.

# Related issues

<!-- e.g. #123 or Roadmap goal # https://github.com/pirate/ArchiveBox/wiki/Roadmap -->

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
