### PR TITLE
Add bookmarklet link back to add page

### DIFF
--- a/archivebox/templates/core/add.html
+++ b/archivebox/templates/core/add.html
@@ -49,10 +49,10 @@
                 <small>(you will be redirected to your <a href="/">Snapshot list</a> momentarily, its safe to close this page at any time)</small>
             </center>
             {% if absolute_add_path %}
-            <!-- <center id="bookmarklet">
+            <center id="bookmarklet">
               <p>Bookmark this link to quickly add to your archive:
                 <a href="javascript:void(window.open('{{ absolute_add_path }}?url='+encodeURIComponent(document.location.href)));">Add to ArchiveBox</a></p>
-            </center> -->
+            </center>
             {% endif %}
             <script>
                 document.getElementById('add-form').addEventListener('submit', function(event) {


### PR DESCRIPTION
It looks like bookmarklet link was accidently removed in 63c276a

<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

Adds missing bookmarklet link to add page template

# Related issues

<!-- e.g. #123 or Roadmap goal # https://github.com/pirate/ArchiveBox/wiki/Roadmap -->

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
