### PR TITLE
Make "DOCS" link in navigation bar open in new tab

### DIFF
--- a/archivebox/templates/core/navigation.html
+++ b/archivebox/templates/core/navigation.html
@@ -5,7 +5,7 @@
     <a href="{% url 'Home' %}">Snapshots</a> |
     <a href="/admin/core/tag/">Tags</a> |
     <a href="/admin/core/archiveresult/?o=-1">Log</a> &nbsp; &nbsp;
-    <a href="{% url 'Docs' %}">Docs</a> | 
+    <a href="{% url 'Docs' target="_blank" rel="noopener noreferrer"%}">Docs</a> | 
     <a href="{% url 'public-index' %}">Public</a> | 
     <a href="/admin/">Admin</a>
      &nbsp; &nbsp;


### PR DESCRIPTION
Proposal to have  navigation template so DOCS link open in new tab

# Summary

I'm working with ArchiveBox for the first time, and looking extensively at the Docs as I do (and enjoying it - thanks!). 

I've found it disruptive that the Docs link opens in the same tab: invariably if I want to read docs, I want to do so **alongside** the application.  I realised that this is quite an easy thing to fix by changing the html template, and thought I'd propose it. 

# Side-note

This is my first pull request, so I'm paranoid that I'm doing it wrong. Please bear that in mind when reviewing.

# Changes these areas

- [ ] Bugfixes
- [x] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
