### PR TITLE
Fix for Bug: Search sometimes shows the same snapshot twice #1193

### DIFF
--- a/archivebox/core/mixins.py
+++ b/archivebox/core/mixins.py
@@ -18,4 +18,4 @@ class SearchResultsAdminMixin:
             print(f'[!] Error while using search backend: {err.__class__.__name__} {err}')
             messages.add_message(request, messages.WARNING, f'Error from the search backend, only showing results from default admin search fields - Error: {err}')
         
-        return qs, use_distinct
+        return qs.distinct(), use_distinct


### PR DESCRIPTION
Making sure the search results are unique

# Summary
This PR fixes the bug #1193

Before the fix:
https://github.com/ArchiveBox/ArchiveBox/assets/47631351/283ba41c-2fe9-4ada-9bd3-f5ead7cf9e07

After the fix:
https://github.com/ArchiveBox/ArchiveBox/assets/47631351/d0c60888-d368-4783-8d9a-65cb4127c11c


# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
