### PR TITLE
Use `COOKIES_FILE` to fetch page titles

### DIFF
--- a/archivebox/extractors/__init__.py
+++ b/archivebox/extractors/__init__.py
@@ -131,7 +131,7 @@ def archive_link(link: Link, overwrite: bool=False, methods: Optional[Iterable[s
 
         link = load_link_details(link, out_dir=out_dir)
         write_link_details(link, out_dir=out_dir, skip_sql_index=False)
-        log_link_archiving_started(link, out_dir, is_new)
+        log_link_archiving_started(link, str(out_dir), is_new)
         link = link.overwrite(updated=datetime.now(timezone.utc))
         stats = {'skipped': 0, 'succeeded': 0, 'failed': 0}
         start_ts = datetime.now(timezone.utc)
@@ -165,16 +165,6 @@ def archive_link(link: Link, overwrite: bool=False, methods: Optional[Iterable[s
                     # print('{black}      X {}{reset}'.format(method_name, **ANSI))
                     stats['skipped'] += 1
             except Exception as e:
-                # Disabled until https://github.com/ArchiveBox/ArchiveBox/issues/984
-                # and https://github.com/ArchiveBox/ArchiveBox/issues/1014
-                # are fixed.
-                """
-                raise Exception('Exception in archive_methods.save_{}(Link(url={}))'.format(
-                    method_name,
-                    link.url,
-                )) from e
-                """
-                # Instead, use the kludgy workaround from
                 # https://github.com/ArchiveBox/ArchiveBox/issues/984#issuecomment-1150541627
                 with open(ERROR_LOG, "a", encoding='utf-8') as f:
                     command = ' '.join(sys.argv)

--- a/archivebox/util.py
+++ b/archivebox/util.py
@@ -3,6 +3,7 @@ __package__ = 'archivebox'
 import re
 import requests
 import json as pyjson
+import http.cookiejar
 
 from typing import List, Optional, Any
 from pathlib import Path
@@ -164,13 +165,26 @@ def parse_date(date: Any) -> Optional[datetime]:
 @enforce_types
 def download_url(url: str, timeout: int=None) -> str:
     """Download the contents of a remote url and return the text"""
-    from .config import TIMEOUT, CHECK_SSL_VALIDITY, WGET_USER_AGENT
+    from .config import (
+         TIMEOUT,
+         CHECK_SSL_VALIDITY,
+         WGET_USER_AGENT,
+         COOKIES_FILE,
+    )
     timeout = timeout or TIMEOUT
+
+    cookie_jar = http.cookiejar.MozillaCookieJar()
+    if COOKIES_FILE is not None:
+        cookie_jar.load(COOKIES_FILE, ignore_discard=True, ignore_expires=True)
+    else:
+        cookie_jar = None
+
     response = requests.get(
         url,
         headers={'User-Agent': WGET_USER_AGENT},
         verify=CHECK_SSL_VALIDITY,
         timeout=timeout,
+        cookies=cookie_jar,
     )
 
     content_type = response.headers.get('Content-Type', '')

--- a/archivebox/util.py
+++ b/archivebox/util.py
@@ -166,25 +166,25 @@ def parse_date(date: Any) -> Optional[datetime]:
 def download_url(url: str, timeout: int=None) -> str:
     """Download the contents of a remote url and return the text"""
     from .config import (
-         TIMEOUT,
-         CHECK_SSL_VALIDITY,
-         WGET_USER_AGENT,
-         COOKIES_FILE,
+        TIMEOUT,
+        CHECK_SSL_VALIDITY,
+        WGET_USER_AGENT,
+        COOKIES_FILE,
     )
     timeout = timeout or TIMEOUT
+    session = requests.Session()
 
-    cookie_jar = http.cookiejar.MozillaCookieJar()
-    if COOKIES_FILE is not None:
-        cookie_jar.load(COOKIES_FILE, ignore_discard=True, ignore_expires=True)
-    else:
-        cookie_jar = None
+    if COOKIES_FILE and Path(COOKIES_FILE).is_file():
+        cookie_jar = http.cookiejar.MozillaCookieJar(COOKIES_FILE)
+        cookie_jar.load(ignore_discard=True, ignore_expires=True)
+        for cookie in cookie_jar:
+            session.cookies.set(cookie.name, cookie.value, domain=cookie.domain, path=cookie.path)
 
-    response = requests.get(
+    response = session.get(
         url,
         headers={'User-Agent': WGET_USER_AGENT},
         verify=CHECK_SSL_VALIDITY,
         timeout=timeout,
-        cookies=cookie_jar,
     )
 
     content_type = response.headers.get('Content-Type', '')


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary
This PR lets the title extractor use the `COOKIES_FILE`, if available. This helps avoid extracting the titles of captcha or login pages.
<!--e.g. This PR fixes ABC or adds the ability to do XYZ...-->

# Related issues
#761 
<!-- e.g. #123 or Roadmap goal # https://github.com/pirate/ArchiveBox/wiki/Roadmap -->

# Changes these areas

- [ ] Bugfixes
- [x] Feature behavior
- [ ] Command line interface
- [x] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
