### PR TITLE
Make it a little easier to run specific tests

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -14,4 +14,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && pwd )"
 
 source "$DIR/.venv/bin/activate"
 
-pytest -s --basetemp=tests/out --ignore=archivebox/vendor --ignore=deb_dist --ignore=pip_dist --ignore=brew_dist
+pytest -s --basetemp=tests/out "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,8 @@ lint = "./bin/lint.sh"
 test = "./bin/test.sh"
 # all = {composite = ["lint mypackage/", "test -v tests/"]}
 
+[tool.pytest.ini_options]
+testpaths = [ "tests" ]
 
 [project.scripts]
 archivebox = "archivebox.cli:main"

--- a/tests/mock_server/server.py
+++ b/tests/mock_server/server.py
@@ -50,4 +50,4 @@ def redirect_to_static(filename):
 
 
 def start():
-    run(host='localhost', port=8080)
+    run(host='localhost', port=8080, quiet=True)


### PR DESCRIPTION
# Summary

Changes `./bin/test.sh` to pass command line options through to `pytest`, and default to only running tests in the `tests/` directory instead of everywhere excluding a few directories.

This means you can do things like `./bin/test.sh tests/test_add.py -k json` to just run the JSON-related tests for `add`.

Also keeps the mock_server used in testing quiet so access log entries don't appear on stdout. (Maybe it would be useful to direct the log to a file somewhere but that seemed like more of a hassle than I wanted to tackle for now.)

# Changes these areas

- [ ] Bugfixes
- [ ] Feature behavior
- [X] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
