### PR TITLE
Add COOKIES_FILE support for singlefile extractor

### DIFF
--- a/archivebox/extractors/singlefile.py
+++ b/archivebox/extractors/singlefile.py
@@ -19,6 +19,7 @@ from ..config import (
     SINGLEFILE_VERSION,
     SINGLEFILE_ARGS,
     CHROME_BINARY,
+    COOKIES_FILE,
 )
 from ..logging_util import TimedProgress
 
@@ -48,6 +49,7 @@ def save_singlefile(link: Link, out_dir: Optional[Path]=None, timeout: int=TIMEO
     browser_args = '--browser-args={}'.format(json.dumps(browser_args[1:]))
     options = [
         *SINGLEFILE_ARGS,
+        *(["--browser-cookies-file={}".format(COOKIES_FILE)] if COOKIES_FILE else []),
         '--browser-executable-path={}'.format(CHROME_BINARY),
         browser_args,
     ]


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

Allows the singlefile extractor to make use of the `COOKIES_FILE` option, previously used only by the wget extractor. Superseded by any `--browser-cookies-file` option in `SINGLEFILE_ARGS`.

# Related issues

#829

# Changes these areas

- [ ] Bugfixes
- [x] Feature behavior
- [ ] Command line interface
- [x] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
