### PR TITLE
Move novnc web-ui to 8081

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,9 +105,9 @@ services:
             - DISPLAY_HEIGHT=1080
             - RUN_XTERM=no
         ports:
-            # to view/control ArchiveBox's browser, visit: http://127.0.0.1:8080/vnc.html
+            # to view/control ArchiveBox's browser, visit: http://127.0.0.1:8081/vnc.html
             # restricted to access from localhost by default because it has no authentication
-            - 127.0.0.1:8080:8080
+            - 127.0.0.1:8081:8080
 
 
     ### Example: Put Nginx in front of the ArchiveBox server for SSL termination and static file serving.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,7 @@ services:
             - DISPLAY_HEIGHT=1080
             - RUN_XTERM=no
         ports:
-            # to view/control ArchiveBox's browser, visit: http://127.0.0.1:8081/vnc.html
+            # to view/control ArchiveBox's browser, visit: http://127.0.0.1:8080/vnc.html
             # restricted to access from localhost by default because it has no authentication
             - 127.0.0.1:8080:8080
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,7 @@ services:
         ports:
             # to view/control ArchiveBox's browser, visit: http://127.0.0.1:8081/vnc.html
             # restricted to access from localhost by default because it has no authentication
-            - 127.0.0.1:8081:8080
+            - 127.0.0.1:8080:8080
 
 
     ### Example: Put Nginx in front of the ArchiveBox server for SSL termination and static file serving.
@@ -179,7 +179,7 @@ services:
     #     environment:
     #         - INIT_COLLECTION=archivebox
     #     ports:
-    #         - 8080:8080
+    #         - 8686:8080
     #     volumes:
     #         - ./data:/archivebox
     #         - ./data/wayback:/webarchive


### PR DESCRIPTION
Fix tcp port 8080 being used twice and move novnc web interface to 127.0.0.1:8081

<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

Fix port 8080 being used twice within docker-compose.yml and move novnc web-ui to 127.0.0.1:8081

# Related issues

Fixes #1519

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [x] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
