### PR TITLE
Fix sonic config downloader

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,22 +74,25 @@ services:
     #   $ docker-compose run archivebox update --index-only
     # https://github.com/ArchiveBox/ArchiveBox/wiki/Setting-up-Search
 
-    sonic:
-        image: valeriansaliou/sonic:latest
-        build:
-            # custom build just auto-downloads archivebox's default sonic.cfg as a convenience
-            # not needed after first run / if you have already have ./etc/sonic.cfg present
-            dockerfile_inline: |
-                FROM quay.io/curl/curl:latest AS config_downloader
-                RUN curl -fsSL 'https://raw.githubusercontent.com/ArchiveBox/ArchiveBox/stable/etc/sonic.cfg' > /tmp/sonic.cfg
-                FROM valeriansaliou/sonic:latest
-                COPY --from=config_downloader /tmp/sonic.cfg /etc/sonic.cfg
+    init-sonic:
+        image: quay.io/curl/curl:latest
+        user: root
+        command: ["/bin/sh", "-c", "test -s /run/sonic/sonic.cfg || curl -fsSL 'https://raw.githubusercontent.com/ArchiveBox/ArchiveBox/stable/etc/sonic.cfg' > /run/sonic/sonic.cfg"]          
+        volumes:
+            - ./data/sonic.cfg:/run/sonic     
+            
+    sonic:  
+        depends_on:
+            init-sonic:
+                condition: service_completed_successfully
+        image: valeriansaliou/sonic:latest 
+        command: ["sonic", "-c", "/run/sonic/sonic.cfg"]
         expose:
             - 1491
         environment:
             - SEARCH_BACKEND_PASSWORD=SomeSecretPassword
         volumes:
-            #- ./sonic.cfg:/etc/sonic.cfg:ro    # use this if you prefer to download the config on the host and mount it manually
+            - ./data/sonic.cfg:/run/sonic
             - ./data/sonic:/var/lib/sonic/store
 
 


### PR DESCRIPTION
Rewrite sonic container init to fixe the issue that when ./sonic.cfg does not already exist as a file having docker-compose create a folder with that name instead.

<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

Rewrite sonic config downloader

# Related issues

Fixes #1521

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
