### PR TITLE
Fix API crash

### DIFF
--- a/archivebox/api/v1_api.py
+++ b/archivebox/api/v1_api.py
@@ -64,7 +64,7 @@ class NinjaAPIWithIOCapture(NinjaAPI):
 
         # Add Auth Headers to response
         api_token = getattr(request, '_api_token', None)
-        token_expiry = api_token.expires.isoformat() if api_token else 'Never'
+        token_expiry = api_token.expires.isoformat() if api_token and api_token.expires else 'Never'
 
         response['X-ArchiveBox-Auth-Method'] = getattr(request, '_api_auth_method', None) or 'None'
         response['X-ArchiveBox-Auth-Expires'] = token_expiry


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary
This PR fixes a crash caused by using an API token without an expiration.
<!--e.g. This PR fixes ABC or adds the ability to do XYZ...-->

# Related issues
#1565
<!-- e.g. #123 or Roadmap goal # https://github.com/pirate/ArchiveBox/wiki/Roadmap -->

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Internal architecture
- [ ] Configuration options
- [ ] Snapshot data layout on disk
