### PR TITLE
fix syntax errors

### DIFF
--- a/archivebox/extractors/extractor.py
+++ b/archivebox/extractors/extractor.py
@@ -194,7 +194,6 @@ class Extractor:
                 self.archiveresult.outputs.append({
                     'type': 'PDF',
                     'path': file.relative_to(cwd),
-                    ''
                 })
                 
             if 'text/plain' in mimetypes.guess_type(file):

--- a/archivebox/pkgs/abx-plugin-title/abx_plugin_title/extractor.py
+++ b/archivebox/pkgs/abx-plugin-title/abx_plugin_title/extractor.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from archivebox.index.schema import Link, ArchiveResult, ArchiveOutput, ArchiveError
 from archivebox.misc.logging_util import TimedProgress
-from archivebox.misc.util import enforce_types, download_url, htmldecode, dedupe)
+from archivebox.misc.util import enforce_types, download_url, htmldecode, dedupe
 
 from abx_plugin_curl.config import CURL_CONFIG
 from abx_plugin_curl.binaries import CURL_BINARY


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

Fixes two syntax errors, one in abx-plugin-title, and one in archivebox.extractors.extractor.

# Related issues

N/A

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
