### PR TITLE
fix syntax error in archivebox/core/models.py

### DIFF
--- a/archivebox/core/models.py
+++ b/archivebox/core/models.py
@@ -33,7 +33,7 @@ from archivebox.index.html import snapshot_icons
 from archivebox.extractors import ARCHIVE_METHODS_INDEXING_PRECEDENCE
 from archivebox.base_models.models import (
     ABIDModel, ABIDField, AutoDateTimeField, get_or_create_system_user_pk,
-    ModelWithReadOnlyFields, ModelWithSerializers, ModelWithUUID, ModelWithKVTags  # ModelWithStateMachine
+    ModelWithReadOnlyFields, ModelWithSerializers, ModelWithUUID, ModelWithKVTags,  # ModelWithStateMachine
     ModelWithOutputDir, ModelWithConfig, ModelWithNotes, ModelWithHealthStats
 )
 from workers.models import ModelWithStateMachine


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

This missing comma is a syntax error and causes issues running the app.

# Related issues

N/A

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
