### PR TITLE
Fix typo in timestamp scale factor

### DIFF
--- a/archivebox/parsers/generic_json.py
+++ b/archivebox/parsers/generic_json.py
@@ -26,7 +26,7 @@ def jsonObjectToLink(link: str, source: str):
     ts_str = str(datetime.now(timezone.utc).timestamp())
     if link.get('timestamp'):
         # chrome/ff histories use a very precise timestamp
-        ts_str = str(link['timestamp'] / 10000000)
+        ts_str = str(link['timestamp'] / 1000000)
     elif link.get('time'):
         ts_str = str(json_date(link['time'].split(',', 1)[0]).timestamp())
     elif link.get('created_at'):


### PR DESCRIPTION
I noticed that importing using timestamps doesn't seem to work. This is probably a typo. The timestamps are in microseconds (divide by 1e6). There is an extra zero there.