### PR TITLE
Fix two small errors in abx-{readwise,spec-config}

### DIFF
--- a/archivebox/pkgs/abx-plugin-readwise/abx_plugin_readwise.py
+++ b/archivebox/pkgs/abx-plugin-readwise/abx_plugin_readwise.py
@@ -15,11 +15,10 @@ from pydantic import Field
 
 from abx_spec_config.base_configset import BaseConfigSet
 
-SOURCES_DIR = abx.pm.hook.get_CONFIG().SOURCES_DIR
-
+from archivebox.config import CONSTANTS
 
 class ReadwiseConfig(BaseConfigSet):
-    READWISE_DB_PATH: Path                  = Field(default=SOURCES_DIR / "readwise_reader_api.db")
+    READWISE_DB_PATH: Path                  = Field(default=CONSTANTS.SOURCES_DIR / "readwise_reader_api.db")
     READWISE_READER_TOKENS: Dict[str, str]  = Field(default=lambda: {})   # {<username>: <access_token>, ...}
 
 

--- a/archivebox/pkgs/abx-spec-config/abx_spec_config/__init__.py
+++ b/archivebox/pkgs/abx-spec-config/abx_spec_config/__init__.py
@@ -33,7 +33,7 @@ class ConfigPluginSpec:
     @abx.hookspec
     @abx.hookimpl
     def get_CONFIG() -> dict[abx.PluginId, 'BaseConfigSet | ConstantsDict']:
-        from archivebox import CONSTANTS
+        from archivebox.config import CONSTANTS
         """Get the config for a single plugin -> {plugin_id: PluginConfigSet()}"""
         return {
             'CONSTANTS': CONSTANTS,


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

Fixes various minor errors I got while testing https://github.com/NixOS/nixpkgs/pull/354836 (on python 3.12 if that matters). See full commit messages for them.

Note: I am no longer affiliated with the NixOS project.

# Changes these areas

- [X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk

