### PR TITLE
Kill the timer process if it doesn't properly terminate.

### DIFF
--- a/archivebox/misc/logging_util.py
+++ b/archivebox/misc/logging_util.py
@@ -155,9 +155,10 @@ class TimedProgress:
                 time.sleep(0.1)
                 # sometimes the timer doesn't terminate properly, then blocks at the join until
                 # the full time has elapsed. sending a kill tries to avoid that.
-                if self.p.is_alive():
+                try:
                     self.p.kill() 
-                self.p.join()
+                except Exception:
+                    pass
 
 
                 # clear whole terminal line

--- a/archivebox/misc/logging_util.py
+++ b/archivebox/misc/logging_util.py
@@ -152,6 +152,11 @@ class TimedProgress:
                 except BaseException:                                           # lgtm [py/catch-base-exception]
                     pass
                 self.p.terminate()
+                time.sleep(0.1)
+                # sometimes the timer doesn't terminate properly, then blocks at the join until
+                # the full time has elapsed. sending a kill tries to avoid that.
+                if self.p.is_alive():
+                    self.p.kill() 
                 self.p.join()
 
 


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary
This tries to fix the problem described in #1646. I ended up using `kill()` instead of the solution presented there because it turns out the behavior varied from run to run, and I couldn't get that solution to work consistently. Sending a kill signal was the simplest and most consistent fix. There may be some downsides I'm missing.
<!--e.g. This PR fixes ABC or adds the ability to do XYZ...-->

# Related issues
#1646 
<!-- e.g. #123 or Roadmap goal # https://github.com/pirate/ArchiveBox/wiki/Roadmap -->

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
