### PR TITLE
abx-plugin-title: use CURL_USER_AGENT when downloading page

### DIFF
--- a/archivebox/misc/util.py
+++ b/archivebox/misc/util.py
@@ -209,7 +209,7 @@ def parse_date(date: Any) -> datetime:
 
 
 @enforce_types
-def download_url(url: str, timeout: int=None) -> str:
+def download_url(url: str, timeout: Optional[int]=None, useragent: Optional[str]=None) -> str:
     """Download the contents of a remote url and return the text"""
 
     from archivebox.config.common import ARCHIVING_CONFIG
@@ -225,7 +225,7 @@ def download_url(url: str, timeout: int=None) -> str:
 
     response = session.get(
         url,
-        headers={'User-Agent': ARCHIVING_CONFIG.USER_AGENT},
+        headers={'User-Agent': useragent or ARCHIVING_CONFIG.USER_AGENT},
         verify=ARCHIVING_CONFIG.CHECK_SSL_VALIDITY,
         timeout=timeout,
     )

--- a/archivebox/pkgs/abx-plugin-title/abx_plugin_title/extractor.py
+++ b/archivebox/pkgs/abx-plugin-title/abx_plugin_title/extractor.py
@@ -69,7 +69,7 @@ def get_html(link: Link, path: Path, timeout: int=CURL_CONFIG.CURL_TIMEOUT) -> s
         except (FileNotFoundError, TypeError, UnicodeDecodeError):
             continue
     if document is None:
-        return download_url(link.url, timeout=timeout)
+        return download_url(link.url, timeout=timeout, useragent=CURL_CONFIG.CURL_USER_AGENT)
     else:
         return document
 


### PR DESCRIPTION
abx-plugin-title fetches the title with whatever works first:

- reuse already downloaded page with dom/singlepage/wget
- download the page with python-requests

the plugin documents/returns a curl command-line but it's never used. See https://github.com/ArchiveBox/ArchiveBox/issues/1670

At least we could mimick curl behaviour when downloading the page with python-requests by using the CURL_USER_AGENT setting.

<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

<!--e.g. This PR fixes ABC or adds the ability to do XYZ...-->

# Related issues

<!-- e.g. #123 or Roadmap goal # https://github.com/pirate/ArchiveBox/wiki/Roadmap -->

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
