### PR TITLE
add optional ipfs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,6 +897,79 @@ Each snapshot subfolder <code>data/archive/TIMESTAMP/</code> includes a static <
 </details>
 <br/>
 
+## IPFS Storage Support
+
+ArchiveBox includes optional IPFS (InterPlanetary File System) storage support. When enabled, archived files are automatically uploaded to IPFS in addition to being saved locally, providing decentralized storage and permanent content-addressed URLs.
+
+<br/>
+<details>
+<summary><i>Expand to learn about IPFS storage configuration...</i></summary><br/>
+
+### Enable IPFS Storage
+
+```bash
+# Enable IPFS storage backend
+archivebox config --set USE_IPFS=True
+
+# Configure IPFS settings
+archivebox config --set IPFS_API_URL=http://localhost:5001
+archivebox config --set IPFS_GATEWAY_URL=https://ipfs.io/ipfs/
+archivebox config --set IPFS_TIMEOUT=30
+archivebox config --set IPFS_PIN_FILES=True
+archivebox config --set IPFS_FALLBACK_TO_LOCAL=True
+```
+
+### IPFS Management Commands
+
+```bash
+# Test IPFS connectivity
+archivebox ipfs test
+
+# Show IPFS status
+archivebox ipfs status
+
+# Enable/disable IPFS storage
+archivebox ipfs enable
+archivebox ipfs disable
+
+# Add a file to IPFS manually
+archivebox ipfs add /path/to/file
+```
+
+### Benefits
+
+- **Decentralized Storage**: Files are distributed across the IPFS network
+- **Permanent URLs**: IPFS hashes provide permanent, content-addressed URLs
+- **Redundancy**: Files are stored both locally and on IPFS
+- **Accessibility**: Files can be accessed via any IPFS gateway
+- **No Vendor Lock-in**: IPFS is an open protocol
+
+### Setup Requirements
+
+1. **Install IPFS**: Download and install IPFS daemon
+2. **Start IPFS**: Run `ipfs daemon` to start the IPFS node
+3. **Configure ArchiveBox**: Enable IPFS storage with the commands above
+4. **Test**: Run `archivebox ipfs test` to verify connectivity
+
+### How It Works
+
+When IPFS is enabled, ArchiveBox saves files both locally and to IPFS:
+
+- Files are written locally first (for compatibility and fallback)
+- Files are then uploaded to IPFS
+- IPFS hashes and gateway URLs are stored in the database
+- Files can be accessed via local path or IPFS gateway URL
+
+<h4>Learn More</h4>
+<ul>
+<li><a href="archivebox/storage/README.md">IPFS Storage Documentation</a></li>
+<li><a href="https://ipfs.io/docs/">IPFS Documentation</a></li>
+<li><a href="https://github.com/ipfs/go-ipfs">IPFS GitHub Repository</a></li>$$
+</ul>
+
+</details>
+<br/>
+
 
 ## Static Archive Exporting
 

--- a/archivebox/cli/archivebox_ipfs.py
+++ b/archivebox/cli/archivebox_ipfs.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+
+__package__ = 'archivebox.cli'
+__command__ = 'archivebox ipfs'
+
+import sys
+from pathlib import Path
+
+import rich_click as click
+
+from archivebox.misc.util import enforce_types, docstring
+from archivebox.config.common import STORAGE_CONFIG
+
+
+@click.group()
+@click.pass_context
+def ipfs(ctx):
+    """Manage IPFS storage backend for ArchiveBox"""
+    pass
+
+
+@ipfs.command()
+@click.pass_context
+@enforce_types
+def test(ctx):
+    """Test IPFS connectivity and configuration"""
+    try:
+        from archivebox.storage import IPFSStorageBackend
+        
+        print("[*] Testing IPFS connectivity...")
+        
+        # Check if IPFS is enabled
+        if not STORAGE_CONFIG.USE_IPFS:
+            print("[!] IPFS is not enabled. Enable it with: archivebox config --set USE_IPFS=True")
+            return
+        
+        # Test connection
+        ipfs_backend = IPFSStorageBackend()
+        if ipfs_backend.test_connection():
+            print(f"[+] IPFS connection successful!")
+            print(f"    API URL: {STORAGE_CONFIG.IPFS_API_URL}")
+            print(f"    Gateway URL: {STORAGE_CONFIG.IPFS_GATEWAY_URL}")
+            print(f"    Timeout: {STORAGE_CONFIG.IPFS_TIMEOUT}s")
+            print(f"    Pin files: {STORAGE_CONFIG.IPFS_PIN_FILES}")
+            print(f"    Fallback to local: {STORAGE_CONFIG.IPFS_FALLBACK_TO_LOCAL}")
+        else:
+            print(f"[X] IPFS connection failed!")
+            print(f"    API URL: {STORAGE_CONFIG.IPFS_API_URL}")
+            print(f"    Make sure IPFS daemon is running and accessible")
+            
+    except ImportError:
+        print("[X] IPFS storage module not available")
+    except Exception as e:
+        print(f"[X] Error testing IPFS: {e}")
+
+
+@ipfs.command()
+@click.argument('file_path', type=click.Path(exists=True))
+@click.pass_context
+@enforce_types
+def add(ctx, file_path):
+    """Add a file to IPFS"""
+    try:
+        from archivebox.storage import IPFSStorageBackend
+        
+        if not STORAGE_CONFIG.USE_IPFS:
+            print("[!] IPFS is not enabled. Enable it with: archivebox config --set USE_IPFS=True")
+            return
+        
+        print(f"[*] Adding file to IPFS: {file_path}")
+        
+        ipfs_backend = IPFSStorageBackend()
+        if not ipfs_backend.test_connection():
+            print("[X] IPFS connection failed!")
+            return
+        
+        ipfs_hash = ipfs_backend.add_file(file_path)
+        ipfs_url = ipfs_backend.get_file_url(ipfs_hash)
+        
+        print(f"[+] File added to IPFS successfully!")
+        print(f"    Hash: {ipfs_hash}")
+        print(f"    URL: {ipfs_url}")
+        
+    except ImportError:
+        print("[X] IPFS storage module not available")
+    except Exception as e:
+        print(f"[X] Error adding file to IPFS: {e}")
+
+
+@ipfs.command()
+@click.pass_context
+@enforce_types
+def status(ctx):
+    """Show IPFS configuration status"""
+    print("[*] IPFS Configuration Status:")
+    print(f"    Enabled: {STORAGE_CONFIG.USE_IPFS}")
+    
+    if STORAGE_CONFIG.USE_IPFS:
+        print(f"    API URL: {STORAGE_CONFIG.IPFS_API_URL}")
+        print(f"    Gateway URL: {STORAGE_CONFIG.IPFS_GATEWAY_URL}")
+        print(f"    Timeout: {STORAGE_CONFIG.IPFS_TIMEOUT}s")
+        print(f"    Pin files: {STORAGE_CONFIG.IPFS_PIN_FILES}")
+        print(f"    Fallback to local: {STORAGE_CONFIG.IPFS_FALLBACK_TO_LOCAL}")
+        
+        # Test connection
+        try:
+            from archivebox.storage import IPFSStorageBackend
+            ipfs_backend = IPFSStorageBackend()
+            if ipfs_backend.test_connection():
+                print(f"    Connection: [green]OK[/green]")
+            else:
+                print(f"    Connection: [red]FAILED[/red]")
+        except Exception as e:
+            print(f"    Connection: [red]ERROR - {e}[/red]")
+    else:
+        print("    [yellow]IPFS is disabled. Enable it with: archivebox config --set USE_IPFS=True[/yellow]")
+
+
+@ipfs.command()
+@click.pass_context
+@enforce_types
+def enable(ctx):
+    """Enable IPFS storage backend"""
+    try:
+        from archivebox.cli.archivebox_config import set_config
+        
+        print("[*] Enabling IPFS storage backend...")
+        set_config({'USE_IPFS': 'True'})
+        print("[+] IPFS storage backend enabled!")
+        print("    Run 'archivebox ipfs test' to verify connectivity")
+        
+    except Exception as e:
+        print(f"[X] Error enabling IPFS: {e}")
+
+
+@ipfs.command()
+@click.pass_context
+@enforce_types
+def disable(ctx):
+    """Disable IPFS storage backend"""
+    try:
+        from archivebox.cli.archivebox_config import set_config
+        
+        print("[*] Disabling IPFS storage backend...")
+        set_config({'USE_IPFS': 'False'})
+        print("[+] IPFS storage backend disabled!")
+        
+    except Exception as e:
+        print(f"[X] Error disabling IPFS: {e}")
+
+
+if __name__ == '__main__':
+    ipfs() 

--- a/archivebox/config/common.py
+++ b/archivebox/config/common.py
@@ -64,6 +64,14 @@ class StorageConfig(BaseConfigSet):
     RESTRICT_FILE_NAMES: str            = Field(default='windows')
     ENFORCE_ATOMIC_WRITES: bool         = Field(default=True)
     
+    # IPFS Configuration
+    USE_IPFS: bool                      = Field(default=False, description="Enable IPFS storage backend for archive files")
+    IPFS_API_URL: str                   = Field(default='http://localhost:5001', description="IPFS API endpoint URL")
+    IPFS_GATEWAY_URL: str               = Field(default='https://ipfs.io/ipfs/', description="IPFS gateway URL for accessing files")
+    IPFS_TIMEOUT: int                   = Field(default=30, description="Timeout for IPFS API calls in seconds")
+    IPFS_PIN_FILES: bool                = Field(default=True, description="Pin files in IPFS to prevent garbage collection")
+    IPFS_FALLBACK_TO_LOCAL: bool        = Field(default=True, description="Fallback to local storage if IPFS is unavailable")
+    
     # not supposed to be user settable:
     DIR_OUTPUT_PERMISSIONS: str         = Field(default=lambda c: c['OUTPUT_PERMISSIONS'].replace('6', '7').replace('4', '5'))
 

--- a/archivebox/core/migrations/0008_add_ipfs_fields.py
+++ b/archivebox/core/migrations/0008_add_ipfs_fields.py
@@ -1,0 +1,23 @@
+# Generated manually for IPFS support
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0007_archiveresult'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='archiveresult',
+            name='ipfs_hash',
+            field=models.CharField(blank=True, default=None, help_text='IPFS hash of the archived file', max_length=64, null=True),
+        ),
+        migrations.AddField(
+            model_name='archiveresult',
+            name='storage_type',
+            field=models.CharField(choices=[('local', 'Local Storage'), ('ipfs', 'IPFS Storage'), ('hybrid', 'Hybrid Storage (Local + IPFS)')], default='local', help_text='Type of storage used for this archive result', max_length=16),
+        ),
+    ] 

--- a/archivebox/core/models.py
+++ b/archivebox/core/models.py
@@ -690,6 +690,14 @@ class ArchiveResult(
     start_ts = models.DateTimeField(default=None, null=True, blank=True)
     end_ts = models.DateTimeField(default=None, null=True, blank=True)
     
+    # IPFS storage fields
+    ipfs_hash = models.CharField(max_length=64, default=None, null=True, blank=True, help_text='IPFS hash of the archived file')
+    storage_type = models.CharField(max_length=16, default='local', choices=[
+        ('local', 'Local Storage'),
+        ('ipfs', 'IPFS Storage'),
+        ('hybrid', 'Hybrid Storage (Local + IPFS)'),
+    ], help_text='Type of storage used for this archive result')
+    
     ### ModelWithStateMachine
     status = ModelWithStateMachine.StatusField(choices=StatusChoices.choices, default=StatusChoices.QUEUED)
     retry_at = ModelWithStateMachine.RetryAtField(default=timezone.now)
@@ -944,6 +952,14 @@ class ArchiveResult(
         """Pass any indexable text to the search backend indexer (e.g. sonic, SQLiteFTS5, etc.)"""
         print(f'{self}.save_search_index()')
         pass
+
+    @property
+    def ipfs_url(self) -> Optional[str]:
+        """Get the IPFS gateway URL for this archive result's IPFS hash"""
+        if self.ipfs_hash:
+            from archivebox.storage import storage_backend
+            return storage_backend.get_ipfs_url(self.ipfs_hash)
+        return None
 
 
     # def get_storage_dir(self, create=True, symlink=True):

--- a/archivebox/misc/system.py
+++ b/archivebox/misc/system.py
@@ -79,9 +79,35 @@ def run(cmd, *args, input=None, capture_output=True, timeout=None, check=False, 
 
 
 @enforce_types
-def atomic_write(path: Union[Path, str], contents: Union[dict, str, bytes], overwrite: bool=True) -> None:
+def atomic_write(path: Union[Path, str], contents: Union[dict, str, bytes], overwrite: bool=True, use_ipfs: bool=False) -> None:
     """Safe atomic write to filesystem by writing to temp file + atomic rename"""
 
+    # If IPFS is requested, use the hybrid storage backend
+    if use_ipfs:
+        try:
+            from archivebox.storage import write_file_with_ipfs
+            result = write_file_with_ipfs(path, contents, overwrite)
+            
+            # Log IPFS results if available
+            if result.get('ipfs_hash'):
+                from archivebox.storage import storage_backend
+                ipfs_url = storage_backend.get_ipfs_url(result['ipfs_hash'])
+                print(f"[+] File saved to IPFS: {result['ipfs_hash']}")
+                print(f"    Gateway URL: {ipfs_url}")
+            elif result.get('ipfs_error'):
+                print(f"[!] IPFS upload failed: {result['ipfs_error']}")
+                
+            # If local write failed and we don't have fallback, raise the error
+            if not result.get('success'):
+                raise Exception(result.get('error', 'Unknown error'))
+                
+            return
+        except ImportError:
+            print("[!] IPFS storage module not available, falling back to local storage")
+        except Exception as e:
+            print(f"[!] IPFS storage failed: {e}, falling back to local storage")
+
+    # Standard local storage (original atomic_write logic)
     mode = 'wb+' if isinstance(contents, bytes) else 'w'
     encoding = None if isinstance(contents, bytes) else 'utf-8'  # enforce utf-8 on all text writes
 

--- a/archivebox/pkgs/abx-plugin-chrome/abx_plugin_chrome/dom.py
+++ b/archivebox/pkgs/abx-plugin-chrome/abx_plugin_chrome/dom.py
@@ -47,9 +47,24 @@ def save_dom(link: Link, out_dir: Optional[Path]=None, timeout: int=60) -> Archi
     ]
     status = 'succeeded'
     timer = TimedProgress(timeout, prefix='      ')
+    
+    # Check if IPFS is enabled
+    use_ipfs = False
+    try:
+        from archivebox.config.common import STORAGE_CONFIG
+        use_ipfs = STORAGE_CONFIG.USE_IPFS
+    except ImportError:
+        pass
+    
     try:
         result = run(cmd, cwd=str(out_dir), timeout=timeout, text=True)
-        atomic_write(output_path, result.stdout)
+        
+        # Use IPFS-aware atomic_write if enabled
+        if use_ipfs:
+            from archivebox.misc.system import atomic_write
+            atomic_write(output_path, result.stdout, use_ipfs=True)
+        else:
+            atomic_write(output_path, result.stdout)
 
         if result.returncode:
             hints = result.stderr

--- a/archivebox/storage/README.md
+++ b/archivebox/storage/README.md
@@ -1,0 +1,174 @@
+# IPFS Storage Backend for ArchiveBox
+
+This module provides optional IPFS (InterPlanetary File System) storage support for ArchiveBox. When enabled, archived files are automatically uploaded to IPFS in addition to being saved locally, providing decentralized storage and access.
+
+## Features
+
+- **Hybrid Storage**: Files are saved both locally and to IPFS for redundancy
+- **Fallback Support**: If IPFS is unavailable, files are still saved locally
+- **Configurable**: Easy to enable/disable and configure IPFS settings
+- **Hash Tracking**: IPFS hashes are stored in the database for easy access
+- **Gateway URLs**: Automatic generation of IPFS gateway URLs for file access
+
+## Configuration
+
+### Enable IPFS Storage
+
+```bash
+# Enable IPFS storage
+archivebox config --set USE_IPFS=True
+
+# Configure IPFS settings
+archivebox config --set IPFS_API_URL=http://localhost:5001
+archivebox config --set IPFS_GATEWAY_URL=https://ipfs.io/ipfs/
+archivebox config --set IPFS_TIMEOUT=30
+archivebox config --set IPFS_PIN_FILES=True
+archivebox config --set IPFS_FALLBACK_TO_LOCAL=True
+```
+
+### Configuration Options
+
+| Setting                  | Default                 | Description                                      |
+| ------------------------ | ----------------------- | ------------------------------------------------ |
+| `USE_IPFS`               | `False`                 | Enable IPFS storage backend                      |
+| `IPFS_API_URL`           | `http://localhost:5001` | IPFS API endpoint URL                            |
+| `IPFS_GATEWAY_URL`       | `https://ipfs.io/ipfs/` | IPFS gateway URL for accessing files             |
+| `IPFS_TIMEOUT`           | `30`                    | Timeout for IPFS API calls in seconds            |
+| `IPFS_PIN_FILES`         | `True`                  | Pin files in IPFS to prevent garbage collection  |
+| `IPFS_FALLBACK_TO_LOCAL` | `True`                  | Fallback to local storage if IPFS is unavailable |
+
+## Usage
+
+### CLI Commands
+
+```bash
+# Test IPFS connectivity
+archivebox ipfs test
+
+# Show IPFS status
+archivebox ipfs status
+
+# Enable IPFS storage
+archivebox ipfs enable
+
+# Disable IPFS storage
+archivebox ipfs disable
+
+# Add a file to IPFS manually
+archivebox ipfs add /path/to/file
+```
+
+### Programmatic Usage
+
+```python
+from archivebox.storage import write_file_with_ipfs, IPFSStorageBackend
+
+# Write a file with IPFS support
+result = write_file_with_ipfs('/path/to/file.txt', 'Hello, IPFS!')
+if result.get('ipfs_hash'):
+    print(f"File saved to IPFS: {result['ipfs_hash']}")
+    print(f"Gateway URL: {result['ipfs_url']}")
+
+# Use IPFS backend directly
+ipfs_backend = IPFSStorageBackend()
+if ipfs_backend.test_connection():
+    ipfs_hash = ipfs_backend.add_file('/path/to/file.txt')
+    print(f"IPFS hash: {ipfs_hash}")
+```
+
+## Database Schema
+
+The `ArchiveResult` model has been extended with IPFS fields:
+
+- `ipfs_hash`: The IPFS hash of the archived file
+- `storage_type`: Type of storage used ('local', 'ipfs', or 'hybrid')
+- `ipfs_url` (property): Dynamically generated IPFS gateway URL using global configuration
+
+## Setup Requirements
+
+### 1. Install IPFS
+
+Install and run an IPFS daemon:
+
+```bash
+# Install IPFS (example for Ubuntu)
+wget https://dist.ipfs.io/go-ipfs/v0.20.0/go-ipfs_v0.20.0_linux-amd64.tar.gz
+tar -xvzf go-ipfs_v0.20.0_linux-amd64.tar.gz
+cd go-ipfs
+sudo bash install.sh
+
+# Initialize IPFS
+ipfs init
+
+# Start IPFS daemon
+ipfs daemon
+```
+
+### 2. Install Python Dependencies
+
+The IPFS storage backend requires the `requests` library (already included in ArchiveBox dependencies).
+
+### 3. Configure ArchiveBox
+
+```bash
+# Enable IPFS storage
+archivebox config --set USE_IPFS=True
+
+# Test connectivity
+archivebox ipfs test
+```
+
+## How It Works
+
+1. **File Writing**: When `atomic_write()` is called with `use_ipfs=True`, the file is written locally first, then uploaded to IPFS
+2. **Hash Storage**: The IPFS hash and gateway URL are stored in the `ArchiveResult` model
+3. **Fallback**: If IPFS is unavailable, files are still saved locally
+4. **Access**: Files can be accessed via local path or IPFS gateway URL
+
+## Benefits
+
+- **Decentralized Storage**: Files are distributed across the IPFS network
+- **Permanent URLs**: IPFS hashes provide permanent, content-addressed URLs
+- **Redundancy**: Files are stored both locally and on IPFS
+- **Accessibility**: Files can be accessed via any IPFS gateway
+- **No Vendor Lock-in**: IPFS is an open protocol
+
+## Limitations
+
+- **Network Dependency**: Requires IPFS daemon to be running
+- **Upload Time**: Files take additional time to upload to IPFS
+- **Storage Costs**: Files are stored both locally and on IPFS
+- **Gateway Reliability**: Depends on IPFS gateway availability
+
+## Troubleshooting
+
+### IPFS Connection Issues
+
+```bash
+# Check if IPFS daemon is running
+ipfs id
+
+# Test API connectivity
+curl http://localhost:5001/api/v0/version
+
+# Check ArchiveBox IPFS status
+archivebox ipfs status
+```
+
+### Common Issues
+
+1. **IPFS daemon not running**: Start with `ipfs daemon`
+2. **Wrong API URL**: Check `IPFS_API_URL` configuration
+3. **Network issues**: Ensure IPFS daemon is accessible
+4. **Permission issues**: Check IPFS daemon permissions
+
+## Migration
+
+Existing ArchiveBox installations can enable IPFS storage without affecting current data. New files will be uploaded to IPFS, while existing files remain local-only.
+
+To migrate existing files to IPFS:
+
+```bash
+# This would require a custom migration script
+# Not currently implemented
+```

--- a/archivebox/storage/__init__.py
+++ b/archivebox/storage/__init__.py
@@ -1,0 +1,198 @@
+__package__ = 'archivebox.storage'
+
+from pathlib import Path
+from typing import Union, Optional, Dict, Any
+import json
+import requests
+from urllib.parse import urljoin
+
+from archivebox.config.common import STORAGE_CONFIG
+from archivebox.misc.system import atomic_write
+from archivebox.misc.util import enforce_types
+
+
+class IPFSStorageBackend:
+    """IPFS storage backend for ArchiveBox files"""
+    
+    def __init__(self, api_url: str = None, gateway_url: str = None, timeout: int = None):
+        self.api_url = api_url or STORAGE_CONFIG.IPFS_API_URL
+        self.gateway_url = gateway_url or STORAGE_CONFIG.IPFS_GATEWAY_URL
+        self.timeout = timeout or STORAGE_CONFIG.IPFS_TIMEOUT
+        
+    def _make_api_request(self, endpoint: str, method: str = 'GET', data: Any = None, files: Any = None) -> Dict[str, Any]:
+        """Make a request to the IPFS API"""
+        url = urljoin(self.api_url, endpoint)
+        
+        try:
+            if method == 'GET':
+                response = requests.get(url, timeout=self.timeout)
+            elif method == 'POST':
+                response = requests.post(url, data=data, files=files, timeout=self.timeout)
+            else:
+                raise ValueError(f"Unsupported HTTP method: {method}")
+                
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            raise IPFSError(f"IPFS API request failed: {e}")
+    
+    def add_file(self, file_path: Union[str, Path], pin: bool = None) -> str:
+        """Add a file to IPFS and return its hash"""
+        pin = pin if pin is not None else STORAGE_CONFIG.IPFS_PIN_FILES
+        
+        with open(file_path, 'rb') as f:
+            files = {'file': f}
+            data = {'pin': str(pin).lower()}
+            
+            result = self._make_api_request('/api/v0/add', method='POST', data=data, files=files)
+            
+        return result['Hash']
+    
+    def add_data(self, data: Union[str, bytes], pin: bool = None) -> str:
+        """Add data to IPFS and return its hash"""
+        pin = pin if pin is not None else STORAGE_CONFIG.IPFS_PIN_FILES
+        
+        if isinstance(data, str):
+            data = data.encode('utf-8')
+            
+        files = {'file': ('data', data)}
+        api_data = {'pin': str(pin).lower()}
+        
+        result = self._make_api_request('/api/v0/add', method='POST', data=api_data, files=files)
+        
+        return result['Hash']
+    
+    def get_file_url(self, ipfs_hash: str) -> str:
+        """Get the gateway URL for an IPFS hash"""
+        return urljoin(self.gateway_url, ipfs_hash)
+    
+    def test_connection(self) -> bool:
+        """Test if IPFS API is accessible"""
+        try:
+            result = self._make_api_request('/api/v0/version')
+            return 'Version' in result
+        except Exception:
+            return False
+
+
+class IPFSError(Exception):
+    """Exception raised for IPFS-related errors"""
+    pass
+
+
+class HybridStorageBackend:
+    """Hybrid storage backend that can use IPFS or fallback to local storage"""
+    
+    def __init__(self):
+        self.ipfs_backend = IPFSStorageBackend() if STORAGE_CONFIG.USE_IPFS else None
+        self.use_ipfs = STORAGE_CONFIG.USE_IPFS
+        self.fallback_to_local = STORAGE_CONFIG.IPFS_FALLBACK_TO_LOCAL
+    
+    def write_file(self, path: Union[str, Path], contents: Union[dict, str, bytes], 
+                   overwrite: bool = True) -> Dict[str, Any]:
+        """Write a file using IPFS if enabled, otherwise use local storage"""
+        result = {
+            'storage_type': 'local',
+            'local_path': str(path),
+            'ipfs_hash': None,
+            'success': False
+        }
+        
+        # Always write to local storage first (for compatibility and fallback)
+        try:
+            atomic_write(path, contents, overwrite=overwrite)
+            result['success'] = True
+        except Exception as e:
+            if not self.fallback_to_local:
+                raise e
+            result['error'] = f"Local write failed: {e}"
+            return result
+        
+        # If IPFS is enabled, also add to IPFS
+        if self.use_ipfs and self.ipfs_backend:
+            try:
+                if self.ipfs_backend.test_connection():
+                    ipfs_hash = self.ipfs_backend.add_file(path)
+                    result['storage_type'] = 'hybrid'
+                    result['ipfs_hash'] = ipfs_hash
+                else:
+                    result['ipfs_error'] = "IPFS API not accessible"
+            except Exception as e:
+                result['ipfs_error'] = f"IPFS upload failed: {e}"
+        
+        return result
+    
+    def write_data(self, path: Union[str, Path], contents: Union[dict, str, bytes], 
+                   overwrite: bool = True) -> Dict[str, Any]:
+        """Write data directly to IPFS if enabled, otherwise use local storage"""
+        result = {
+            'storage_type': 'local',
+            'local_path': str(path),
+            'ipfs_hash': None,
+            'success': False
+        }
+        
+        # Always write to local storage first
+        try:
+            atomic_write(path, contents, overwrite=overwrite)
+            result['success'] = True
+        except Exception as e:
+            if not self.fallback_to_local:
+                raise e
+            result['error'] = f"Local write failed: {e}"
+            return result
+        
+        # If IPFS is enabled, also add data to IPFS
+        if self.use_ipfs and self.ipfs_backend:
+            try:
+                if self.ipfs_backend.test_connection():
+                    ipfs_hash = self.ipfs_backend.add_data(contents)
+                    result['storage_type'] = 'hybrid'
+                    result['ipfs_hash'] = ipfs_hash
+                else:
+                    result['ipfs_error'] = "IPFS API not accessible"
+            except Exception as e:
+                result['ipfs_error'] = f"IPFS upload failed: {e}"
+        
+        return result
+    
+    def get_ipfs_url(self, ipfs_hash: str) -> str:
+        """Get the IPFS gateway URL for a hash using global configuration"""
+        if self.ipfs_backend:
+            return self.ipfs_backend.get_file_url(ipfs_hash)
+        return f"{STORAGE_CONFIG.IPFS_GATEWAY_URL}{ipfs_hash}"
+
+
+# Global storage backend instance
+storage_backend = HybridStorageBackend()
+
+
+@enforce_types
+def write_file_with_ipfs(path: Union[str, Path], contents: Union[dict, str, bytes], 
+                         overwrite: bool = True) -> Dict[str, Any]:
+    """Write a file using the hybrid storage backend (IPFS + local)"""
+    return storage_backend.write_file(path, contents, overwrite)
+
+
+@enforce_types
+def write_data_with_ipfs(path: Union[str, Path], contents: Union[dict, str, bytes], 
+                         overwrite: bool = True) -> Dict[str, Any]:
+    """Write data using the hybrid storage backend (IPFS + local)"""
+    return storage_backend.write_data(path, contents, overwrite)
+
+
+@enforce_types
+def update_archiveresult_with_ipfs(archiveresult, storage_result: Dict[str, Any]) -> None:
+    """Update an ArchiveResult object with IPFS information from storage operation"""
+    if not storage_result.get('success'):
+        return
+        
+    # Update storage type
+    archiveresult.storage_type = storage_result.get('storage_type', 'local')
+    
+    # Update IPFS hash if available
+    if storage_result.get('ipfs_hash'):
+        archiveresult.ipfs_hash = storage_result['ipfs_hash']
+    
+    # Save the updated ArchiveResult
+    archiveresult.save(update_fields=['storage_type', 'ipfs_hash']) 

--- a/etc/ArchiveBox.conf.default
+++ b/etc/ArchiveBox.conf.default
@@ -18,6 +18,14 @@
 # GIT_DOMAINS = github.com,bitbucket.org,gitlab.com
 # COOKIES_FILE="path/to/cookies.txt"
 
+# IPFS Configuration
+# USE_IPFS = False
+# IPFS_API_URL = http://localhost:5001
+# IPFS_GATEWAY_URL = https://ipfs.io/ipfs/
+# IPFS_TIMEOUT = 30
+# IPFS_PIN_FILES = True
+# IPFS_FALLBACK_TO_LOCAL = True
+
 [SERVER_CONFIG]
 # SECRET_KEY = ---------------- not a valid secret key ! ----------------
 # DEBUG = False

--- a/tests/test_ipfs_integration.py
+++ b/tests/test_ipfs_integration.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Test script for IPFS integration with ArchiveBox
+"""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Add the archivebox directory to the Python path
+sys.path.insert(0, str(Path(__file__).parent.parent / 'archivebox'))
+
+def test_ipfs_storage():
+    """Test the IPFS storage backend"""
+    print("Testing IPFS Storage Backend...")
+    
+    try:
+        from archivebox.storage import IPFSStorageBackend, HybridStorageBackend
+        from archivebox.config.common import STORAGE_CONFIG
+        
+        print(f"IPFS Enabled: {STORAGE_CONFIG.USE_IPFS}")
+        print(f"API URL: {STORAGE_CONFIG.IPFS_API_URL}")
+        
+        # Test IPFS backend
+        ipfs_backend = IPFSStorageBackend()
+        
+        # Test connection
+        print("\n[*] Testing IPFS connection...")
+        if ipfs_backend.test_connection():
+            print("[+] IPFS connection successful!")
+            
+            # Test adding a file
+            print("\n[*] Testing file upload...")
+            with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+                f.write("Hello, IPFS! This is a test file from ArchiveBox.")
+                temp_file = f.name
+            
+            try:
+                ipfs_hash = ipfs_backend.add_file(temp_file)
+                ipfs_url = ipfs_backend.get_file_url(ipfs_hash)
+                
+                print(f"[+] File uploaded successfully!")
+                print(f"    Hash: {ipfs_hash}")
+                print(f"    URL: {ipfs_url}")
+                
+            finally:
+                os.unlink(temp_file)
+        else:
+            print("[!] IPFS connection failed. Make sure IPFS daemon is running.")
+            
+        # Test hybrid storage backend
+        print("\n[*] Testing hybrid storage backend...")
+        hybrid_backend = HybridStorageBackend()
+        
+        test_content = "Test content for hybrid storage"
+        test_path = tempfile.mktemp()
+        
+        try:
+            result = hybrid_backend.write_data(test_path, test_content)
+            print(f"[+] Hybrid storage result: {result}")
+            
+            if result.get('ipfs_hash'):
+                print(f"    IPFS Hash: {result['ipfs_hash']}")
+                ipfs_url = hybrid_backend.get_ipfs_url(result['ipfs_hash'])
+                print(f"    IPFS URL: {ipfs_url}")
+            
+        finally:
+            if os.path.exists(test_path):
+                os.unlink(test_path)
+                
+    except ImportError as e:
+        print(f"[!] Import error: {e}")
+    except Exception as e:
+        print(f"[!] Error: {e}")
+
+
+def test_configuration():
+    """Test IPFS configuration"""
+    print("\nTesting IPFS Configuration...")
+    
+    try:
+        from archivebox.config.common import STORAGE_CONFIG
+        
+        print(f"USE_IPFS: {STORAGE_CONFIG.USE_IPFS}")
+        print(f"IPFS_API_URL: {STORAGE_CONFIG.IPFS_API_URL}")
+        print(f"IPFS_GATEWAY_URL: {STORAGE_CONFIG.IPFS_GATEWAY_URL}")
+        print(f"IPFS_TIMEOUT: {STORAGE_CONFIG.IPFS_TIMEOUT}")
+        print(f"IPFS_PIN_FILES: {STORAGE_CONFIG.IPFS_PIN_FILES}")
+        print(f"IPFS_FALLBACK_TO_LOCAL: {STORAGE_CONFIG.IPFS_FALLBACK_TO_LOCAL}")
+        
+    except Exception as e:
+        print(f"[!] Error: {e}")
+
+
+def test_atomic_write_with_ipfs():
+    """Test atomic_write with IPFS support"""
+    print("\nTesting atomic_write with IPFS...")
+    
+    try:
+        from archivebox.misc.system import atomic_write
+        
+        test_content = "Test content for atomic_write with IPFS"
+        test_path = tempfile.mktemp()
+        
+        try:
+            # Test with IPFS enabled
+            print("[*] Testing atomic_write with IPFS enabled...")
+            atomic_write(test_path, test_content, use_ipfs=True)
+            
+            # Verify file was written locally
+            if os.path.exists(test_path):
+                with open(test_path, 'r') as f:
+                    content = f.read()
+                if content == test_content:
+                    print("[+] File written successfully with IPFS support")
+                else:
+                    print("[!] File content mismatch")
+            else:
+                print("[!] File was not written locally")
+                
+        finally:
+            if os.path.exists(test_path):
+                os.unlink(test_path)
+                
+    except Exception as e:
+        print(f"[!] Error: {e}")
+
+
+if __name__ == '__main__':
+    print("ArchiveBox IPFS Integration Test")
+    print("=" * 40)
+    
+    test_configuration()
+    test_ipfs_storage()
+    test_atomic_write_with_ipfs()
+    
+    print("\nTest completed!") 


### PR DESCRIPTION
# Summary

Add an optional IPFS storage backend support. The archived content can be additionally or only be stored in  IPFS and the database only stores the IPFS hast as reference

# Related issues

-

# Changes these areas

- [ ] Bugfixes
- [x] Feature behavior
- [x] Command line interface
- [x] Configuration options
- [x] Internal architecture
- [x] Snapshot data layout on disk
