### PR TITLE
Fix: Make CUSTOM_TEMPLATES_DIR configurable again

### DIFF
--- a/archivebox/config/common.py
+++ b/archivebox/config/common.py
@@ -66,6 +66,10 @@ class StorageConfig(BaseConfigSet):
     # should not be a remote/network/FUSE mount for speed reasons, otherwise extractors will be slow
     LIB_DIR: Path = Field(default=CONSTANTS.DEFAULT_LIB_DIR)
 
+    # CUSTOM_TEMPLATES_DIR allows users to override default templates
+    # defaults to DATA_DIR / 'user_templates' but can be configured
+    CUSTOM_TEMPLATES_DIR: Path = Field(default=CONSTANTS.CUSTOM_TEMPLATES_DIR)
+
     OUTPUT_PERMISSIONS: str = Field(default="644")
     RESTRICT_FILE_NAMES: str = Field(default="windows")
     ENFORCE_ATOMIC_WRITES: bool = Field(default=True)

--- a/archivebox/config/paths.py
+++ b/archivebox/config/paths.py
@@ -261,7 +261,7 @@ def get_data_locations():
 def get_code_locations():
     from archivebox.config import CONSTANTS
     from archivebox.config.common import STORAGE_CONFIG
-    
+
     return benedict({
         'PACKAGE_DIR': {
             'path': (PACKAGE_DIR).resolve(),
@@ -274,9 +274,9 @@ def get_code_locations():
             'is_valid': os.access(CONSTANTS.STATIC_DIR, os.R_OK) and os.access(CONSTANTS.STATIC_DIR, os.X_OK),                                                # read + list
         },
         'CUSTOM_TEMPLATES_DIR': {
-            'path': CONSTANTS.CUSTOM_TEMPLATES_DIR.resolve(),
-            'enabled': os.path.isdir(CONSTANTS.CUSTOM_TEMPLATES_DIR),
-            'is_valid': os.path.isdir(CONSTANTS.CUSTOM_TEMPLATES_DIR) and os.access(CONSTANTS.CUSTOM_TEMPLATES_DIR, os.R_OK),                                      # read
+            'path': STORAGE_CONFIG.CUSTOM_TEMPLATES_DIR.resolve(),
+            'enabled': os.path.isdir(STORAGE_CONFIG.CUSTOM_TEMPLATES_DIR),
+            'is_valid': os.path.isdir(STORAGE_CONFIG.CUSTOM_TEMPLATES_DIR) and os.access(STORAGE_CONFIG.CUSTOM_TEMPLATES_DIR, os.R_OK),                                      # read
         },
         'USER_PLUGINS_DIR': {
             'path': CONSTANTS.USER_PLUGINS_DIR.resolve(),

--- a/archivebox/core/settings.py
+++ b/archivebox/core/settings.py
@@ -11,7 +11,7 @@ from django.utils.crypto import get_random_string
 import archivebox
 
 from archivebox.config import DATA_DIR, PACKAGE_DIR, ARCHIVE_DIR, CONSTANTS  # noqa
-from archivebox.config.common import SHELL_CONFIG, SERVER_CONFIG  # noqa
+from archivebox.config.common import SHELL_CONFIG, SERVER_CONFIG, STORAGE_CONFIG  # noqa
 
 
 IS_MIGRATING = "makemigrations" in sys.argv[:3] or "migrate" in sys.argv[:3]
@@ -116,9 +116,9 @@ AUTHENTICATION_BACKENDS = [
 
 STATIC_URL = "/static/"
 TEMPLATES_DIR_NAME = "templates"
-CUSTOM_TEMPLATES_ENABLED = os.path.isdir(CONSTANTS.CUSTOM_TEMPLATES_DIR) and os.access(CONSTANTS.CUSTOM_TEMPLATES_DIR, os.R_OK)
+CUSTOM_TEMPLATES_ENABLED = os.path.isdir(STORAGE_CONFIG.CUSTOM_TEMPLATES_DIR) and os.access(STORAGE_CONFIG.CUSTOM_TEMPLATES_DIR, os.R_OK)
 STATICFILES_DIRS = [
-    *([str(CONSTANTS.CUSTOM_TEMPLATES_DIR / "static")] if CUSTOM_TEMPLATES_ENABLED else []),
+    *([str(STORAGE_CONFIG.CUSTOM_TEMPLATES_DIR / "static")] if CUSTOM_TEMPLATES_ENABLED else []),
     # *[
     #     str(plugin_dir / 'static')
     #     for plugin_dir in PLUGIN_DIRS.values()
@@ -129,7 +129,7 @@ STATICFILES_DIRS = [
 ]
 
 TEMPLATE_DIRS = [
-    *([str(CONSTANTS.CUSTOM_TEMPLATES_DIR)] if CUSTOM_TEMPLATES_ENABLED else []),
+    *([str(STORAGE_CONFIG.CUSTOM_TEMPLATES_DIR)] if CUSTOM_TEMPLATES_ENABLED else []),
     # *[
     #     str(plugin_dir / 'templates')
     #     for plugin_dir in PLUGIN_DIRS.values()


### PR DESCRIPTION
## Summary

Resolves #1484 where CUSTOM_TEMPLATES_DIR configuration was being ignored.

The setting was previously removed from ServerConfig and hardcoded as a constant, preventing users from customizing the templates directory location.

## Changes

- Added CUSTOM_TEMPLATES_DIR field to StorageConfig in common.py
- Updated settings.py to use STORAGE_CONFIG.CUSTOM_TEMPLATES_DIR
- Updated paths.py to use configurable value in version output

## Usage

Users can now configure the custom templates directory via:
- ArchiveBox.conf: `CUSTOM_TEMPLATES_DIR = ./custom_templates`
- Environment variable: `export CUSTOM_TEMPLATES_DIR=/path/to/templates`
- Defaults to DATA_DIR/user_templates if not configured

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores CUSTOM_TEMPLATES_DIR configurability so users can override the templates directory. Fixes issue #1484 and updates the app to consistently use the configured path.

- **Bug Fixes**
  - Added CUSTOM_TEMPLATES_DIR to StorageConfig.
  - Updated settings.py and paths.py to read STORAGE_CONFIG.CUSTOM_TEMPLATES_DIR.

- **Migration**
  - Configure via ArchiveBox.conf or the CUSTOM_TEMPLATES_DIR env var.
  - Defaults to DATA_DIR/user_templates if not set.

<sup>Written for commit 329d185d95d43cdd1a48cf92562bcb10de1d52c8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

