### PR TITLE
fix: Use CustomUserAdmin to fix user creation bug

### DIFF
--- a/archivebox/core/admin.py
+++ b/archivebox/core/admin.py
@@ -7,11 +7,11 @@ from archivebox.core.models import Snapshot, ArchiveResult, Tag
 from archivebox.core.admin_tags import TagAdmin
 from archivebox.core.admin_snapshots import SnapshotAdmin
 from archivebox.core.admin_archiveresults import ArchiveResultAdmin
-from archivebox.core.admin_users import UserAdmin
+from archivebox.core.admin_users import CustomUserAdmin
 
 
 def register_admin(admin_site):
-    admin_site.register(get_user_model(), UserAdmin)
+    admin_site.register(get_user_model(), CustomUserAdmin)
     admin_site.register(ArchiveResult, ArchiveResultAdmin)
     admin_site.register(Snapshot, SnapshotAdmin)
     admin_site.register(Tag, TagAdmin)

--- a/archivebox/core/admin_users.py
+++ b/archivebox/core/admin_users.py
@@ -10,6 +10,12 @@ class CustomUserAdmin(UserAdmin):
     sort_fields = ['id', 'email', 'username', 'is_superuser', 'last_login', 'date_joined']
     list_display = ['username', 'id', 'email', 'is_superuser', 'last_login', 'date_joined']
     readonly_fields = ('snapshot_set', 'archiveresult_set', 'tag_set', 'apitoken_set', 'outboundwebhook_set')
+
+    # Preserve Django's default user creation form and fieldsets
+    # This ensures passwords are properly hashed and permissions are set correctly
+    add_fieldsets = UserAdmin.add_fieldsets
+
+    # Extend fieldsets for change form only (not user creation)
     fieldsets = [*UserAdmin.fieldsets, ('Data', {'fields': readonly_fields})]
 
     @admin.display(description='Snapshots')


### PR DESCRIPTION
### Summary

Fixed the bug where users created via the web GUI cannot login.

### Root Cause

The issue was in `archivebox/core/admin.py` which imported and registered Django's default `UserAdmin` instead of the custom `CustomUserAdmin` class. This bypassed all custom admin logic. Additionally, `CustomUserAdmin` was modifying `fieldsets` without explicitly preserving `add_fieldsets`, which could cause Django to not properly handle the user creation form.

### Changes

- Updated `admin.py` to import and register `CustomUserAdmin`
- Explicitly set `add_fieldsets` in `CustomUserAdmin` to preserve Django's default user creation behavior
- Added explanatory comments

### Testing

To verify the fix:
1. Start ArchiveBox web server
2. Navigate to the admin user creation page (`/admin/auth/user/add/`)
3. Create a new user with staff and superuser permissions
4. Log out and attempt to log in with the new user's credentials
5. Login should now succeed

Fixes #1707

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the bug where users created in the admin couldn’t log in. New users are now created with the correct form and password handling.

- **Bug Fixes**
  - Register CustomUserAdmin instead of Django’s default UserAdmin.
  - Preserve add_fieldsets to keep the default user creation form and password hashing.
  - Apply extra fieldsets only to the change form, not the creation form.

<sup>Written for commit 2e1093f8409dbe426a116a7979e69ece046966a1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

