### PR TITLE
Fix: Make SingleFile use SINGLEFILE_CHROME_ARGS with fallback to CHROME_ARGS

### DIFF
--- a/archivebox/plugins/singlefile/config.json
+++ b/archivebox/plugins/singlefile/config.json
@@ -52,6 +52,13 @@
       "x-fallback": "CHECK_SSL_VALIDITY",
       "description": "Whether to verify SSL certificates"
     },
+    "SINGLEFILE_CHROME_ARGS": {
+      "type": "array",
+      "items": {"type": "string"},
+      "default": [],
+      "x-fallback": "CHROME_ARGS",
+      "description": "Chrome command-line arguments for SingleFile"
+    },
     "SINGLEFILE_ARGS": {
       "type": "array",
       "items": {"type": "string"},

--- a/archivebox/plugins/singlefile/on_Snapshot__50_singlefile.py
+++ b/archivebox/plugins/singlefile/on_Snapshot__50_singlefile.py
@@ -14,6 +14,7 @@ Environment variables:
     SINGLEFILE_USER_AGENT: User agent string (x-fallback: USER_AGENT)
     SINGLEFILE_COOKIES_FILE: Path to cookies file (x-fallback: COOKIES_FILE)
     SINGLEFILE_CHECK_SSL_VALIDITY: Whether to verify SSL certs (x-fallback: CHECK_SSL_VALIDITY)
+    SINGLEFILE_CHROME_ARGS: Chrome command-line arguments (x-fallback: CHROME_ARGS)
     SINGLEFILE_ARGS: Default SingleFile arguments (JSON array)
     SINGLEFILE_ARGS_EXTRA: Extra arguments to append (JSON array)
 """
@@ -134,6 +135,7 @@ def save_singlefile(url: str, binary: str) -> tuple[bool, str | None, str]:
     cookies_file = get_env('SINGLEFILE_COOKIES_FILE') or get_env('COOKIES_FILE', '')
     singlefile_args = get_env_array('SINGLEFILE_ARGS', [])
     singlefile_args_extra = get_env_array('SINGLEFILE_ARGS_EXTRA', [])
+    chrome_args = get_env_array('SINGLEFILE_CHROME_ARGS') or get_env_array('CHROME_ARGS', [])
     chrome = get_env('SINGLEFILE_CHROME_BINARY') or get_env('CHROME_BINARY', '')
 
     cmd = [binary, *singlefile_args]
@@ -148,6 +150,11 @@ def save_singlefile(url: str, binary: str) -> tuple[bool, str | None, str]:
             cmd.extend(['--browser-server', f'http://127.0.0.1:{port}'])
     elif chrome:
         cmd.extend(['--browser-executable-path', chrome])
+
+    # Pass Chrome arguments (includes user-data-dir and other launch options)
+    if chrome_args:
+        # SingleFile expects --browser-args as a JSON array string
+        cmd.extend(['--browser-args', json.dumps(chrome_args)])
 
     # SSL handling
     if not check_ssl:


### PR DESCRIPTION
Fixes #1445

This PR resolves the issue where SingleFile was not respecting Chrome user data directory and other Chrome launch options that work for other Chrome-based extractors (PDF, Screenshot, etc.).

## Changes
- Added `SINGLEFILE_CHROME_ARGS` config option with fallback to `CHROME_ARGS`
- Updated SingleFile extractor to pass Chrome arguments via `--browser-args`
- Updated documentation

This ensures SingleFile respects the same Chrome configuration as other Chrome-based extractors.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes SingleFile honor Chrome launch options by adding SINGLEFILE_CHROME_ARGS (fallback to CHROME_ARGS) and passing them via --browser-args. Fixes #1445 so user-data-dir and other Chrome settings match behavior of other Chrome-based extractors.

- **Bug Fixes**
  - Added SINGLEFILE_CHROME_ARGS config with fallback to CHROME_ARGS.
  - Passed Chrome args to SingleFile using --browser-args (JSON array).
  - Updated extractor docstring to document the new variable.

<sup>Written for commit a101449cba64aaaa6bb6ed9d678915a16e3e9b67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

