### PR TITLE
Fix #1517: Feature Request: Better support for archiving URLs beind HTT

### DIFF
--- a/archivebox/misc/util.py
+++ b/archivebox/misc/util.py
@@ -41,11 +41,12 @@ without_fragment = lambda url: urlparse(url)._replace(fragment='').geturl().stri
 without_path = lambda url: urlparse(url)._replace(path='', fragment='', query='').geturl().strip('//')
 path = lambda url: urlparse(url).path
 basename = lambda url: urlparse(url).path.rsplit('/', 1)[-1]
-domain = lambda url: urlparse(url).netloc
+domain = lambda url: (lambda p: f'{p.hostname}:{p.port}' if p.port else (p.hostname or p.netloc))(urlparse(url))  # returns host:port without HTTP basic auth credentials
 query = lambda url: urlparse(url).query
 fragment = lambda url: urlparse(url).fragment
 extension = lambda url: basename(url).rsplit('.', 1)[-1].lower() if '.' in basename(url) else ''
-base_url = lambda url: without_scheme(url)  # uniq base url used to dedupe links
+without_auth = lambda url: (lambda p: p._replace(netloc=(f'{p.hostname}:{p.port}' if p.port else p.hostname) or '').geturl())(urlparse(url))  # strip HTTP basic auth user:pass@ from URL
+base_url = lambda url: without_scheme(without_auth(url))  # uniq base url used to dedupe links (strips credentials so user:pass@domain == domain)
 
 without_www = lambda url: url.replace('://www.', '://', 1)
 without_trailing_slash = lambda url: url[:-1] if url[-1] == '/' else url.replace('/?', '?')

--- a/archivebox/plugins/parse_html_urls/on_Snapshot__70_parse_html_urls.py
+++ b/archivebox/plugins/parse_html_urls/on_Snapshot__70_parse_html_urls.py
@@ -94,6 +94,38 @@ def fix_urljoin_bug(url: str, nesting_limit=5) -> str:
     return url
 
 
+def inject_url_auth(url: str, root_url: str) -> str:
+    """
+    Inject HTTP basic auth credentials from root_url into url if they share the same host.
+
+    This ensures that when crawling a site with HTTP basic auth (e.g. depth > 0),
+    discovered child URLs on the same host inherit the parent's credentials.
+    Without this, depth > 0 crawls would fail to authenticate on discovered links.
+    """
+    root_parsed = urlparse(root_url)
+    if not root_parsed.username:
+        return url  # No credentials in root URL, nothing to inject
+
+    child_parsed = urlparse(url)
+    if child_parsed.username:
+        return url  # Child URL already has credentials
+
+    # Only inject if same host (hostname and port match)
+    if root_parsed.hostname != child_parsed.hostname or root_parsed.port != child_parsed.port:
+        return url
+
+    # Rebuild netloc with credentials: user:pass@host or user:pass@host:port
+    auth = root_parsed.username
+    if root_parsed.password:
+        auth = f'{root_parsed.username}:{root_parsed.password}'
+    if child_parsed.port:
+        new_netloc = f'{auth}@{child_parsed.hostname}:{child_parsed.port}'
+    else:
+        new_netloc = f'{auth}@{child_parsed.hostname}'
+
+    return child_parsed._replace(netloc=new_netloc).geturl()
+
+
 def normalize_url(url: str, root_url: str = None) -> str:
     """Normalize a URL, resolving relative paths if root_url provided."""
     url = clean_url_candidate(url)
@@ -103,6 +135,8 @@ def normalize_url(url: str, root_url: str = None) -> str:
     url_is_absolute = url.lower().startswith('http://') or url.lower().startswith('https://')
 
     if url_is_absolute:
+        # Inject auth credentials from root URL if child is on the same host
+        url = inject_url_auth(url, root_url)
         return url
 
     # Resolve relative URL
@@ -112,7 +146,12 @@ def normalize_url(url: str, root_url: str = None) -> str:
     if did_urljoin_misbehave(root_url, url, resolved):
         resolved = fix_urljoin_bug(resolved)
 
-    return _normalize_trailing_slash(resolved)
+    resolved = _normalize_trailing_slash(resolved)
+
+    # Inject auth credentials from root URL if child is on the same host
+    resolved = inject_url_auth(resolved, root_url)
+
+    return resolved
 
 
 def _normalize_trailing_slash(url: str) -> str:

--- a/archivebox/plugins/parse_rss_urls/on_Snapshot__72_parse_rss_urls.py
+++ b/archivebox/plugins/parse_rss_urls/on_Snapshot__72_parse_rss_urls.py
@@ -33,6 +33,38 @@ except ImportError:
     feedparser = None
 
 
+def inject_url_auth(url: str, root_url: str) -> str:
+    """
+    Inject HTTP basic auth credentials from root_url into url if they share the same host.
+
+    This ensures that when crawling a site with HTTP basic auth (e.g. depth > 0),
+    discovered child URLs on the same host inherit the parent's credentials.
+    Without this, depth > 0 crawls would fail to authenticate on discovered links.
+    """
+    root_parsed = urlparse(root_url)
+    if not root_parsed.username:
+        return url  # No credentials in root URL, nothing to inject
+
+    child_parsed = urlparse(url)
+    if child_parsed.username:
+        return url  # Child URL already has credentials
+
+    # Only inject if same host (hostname and port match)
+    if root_parsed.hostname != child_parsed.hostname or root_parsed.port != child_parsed.port:
+        return url
+
+    # Rebuild netloc with credentials: user:pass@host or user:pass@host:port
+    auth = root_parsed.username
+    if root_parsed.password:
+        auth = f'{root_parsed.username}:{root_parsed.password}'
+    if child_parsed.port:
+        new_netloc = f'{auth}@{child_parsed.hostname}:{child_parsed.port}'
+    else:
+        new_netloc = f'{auth}@{child_parsed.hostname}'
+
+    return child_parsed._replace(netloc=new_netloc).geturl()
+
+
 def fetch_content(url: str) -> str:
     """Fetch content from a URL (supports file:// and https://)."""
     parsed = urlparse(url)
@@ -113,9 +145,12 @@ def main(url: str, snapshot_id: str = None, crawl_id: str = None, depth: int = 0
                 except (AttributeError, TypeError):
                     pass
 
+            # Propagate HTTP basic auth credentials to discovered URLs on the same host
+            item_url = inject_url_auth(unescape(item_url), url)
+
             entry = {
                 'type': 'Snapshot',
-                'url': unescape(item_url),
+                'url': item_url,
                 'plugin': PLUGIN_NAME,
                 'depth': depth + 1,
             }

--- a/archivebox/plugins/parse_txt_urls/on_Snapshot__71_parse_txt_urls.py
+++ b/archivebox/plugins/parse_txt_urls/on_Snapshot__71_parse_txt_urls.py
@@ -79,6 +79,38 @@ def find_all_urls(text: str):
         yield fix_url_from_markdown(url)
 
 
+def inject_url_auth(url: str, root_url: str) -> str:
+    """
+    Inject HTTP basic auth credentials from root_url into url if they share the same host.
+
+    This ensures that when crawling a site with HTTP basic auth (e.g. depth > 0),
+    discovered child URLs on the same host inherit the parent's credentials.
+    Without this, depth > 0 crawls would fail to authenticate on discovered links.
+    """
+    root_parsed = urlparse(root_url)
+    if not root_parsed.username:
+        return url  # No credentials in root URL, nothing to inject
+
+    child_parsed = urlparse(url)
+    if child_parsed.username:
+        return url  # Child URL already has credentials
+
+    # Only inject if same host (hostname and port match)
+    if root_parsed.hostname != child_parsed.hostname or root_parsed.port != child_parsed.port:
+        return url
+
+    # Rebuild netloc with credentials: user:pass@host or user:pass@host:port
+    auth = root_parsed.username
+    if root_parsed.password:
+        auth = f'{root_parsed.username}:{root_parsed.password}'
+    if child_parsed.port:
+        new_netloc = f'{auth}@{child_parsed.hostname}:{child_parsed.port}'
+    else:
+        new_netloc = f'{auth}@{child_parsed.hostname}'
+
+    return child_parsed._replace(netloc=new_netloc).geturl()
+
+
 def fetch_content(url: str) -> str:
     """Fetch content from a URL (supports file:// and https://)."""
     parsed = urlparse(url)
@@ -125,6 +157,8 @@ def main(url: str, snapshot_id: str = None, crawl_id: str = None, depth: int = 0
         cleaned_url = unescape(found_url)
         # Skip the source URL itself
         if cleaned_url != url:
+            # Propagate HTTP basic auth credentials to discovered URLs on the same host
+            cleaned_url = inject_url_auth(cleaned_url, url)
             urls_found.add(cleaned_url)
 
     # Emit Snapshot records to stdout (JSONL)


### PR DESCRIPTION
Fixes #1517

## Summary
This PR fixes: Feature Request: Better support for archiving URLs beind HTTP basic auth

## Changes
```
archivebox/misc/util.py                            |  5 +--
 .../on_Snapshot__70_parse_html_urls.py             | 41 +++++++++++++++++++++-
 .../on_Snapshot__72_parse_rss_urls.py              | 37 ++++++++++++++++++-
 .../on_Snapshot__71_parse_txt_urls.py              | 34 ++++++++++++++++++
 4 files changed, 113 insertions(+), 4 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: high. Happy to make any adjustments!*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves archiving behind HTTP Basic Auth by propagating credentials to same-host links and stripping creds from URL dedupe helpers. Fixes depth > 0 crawls that failed auth and prevents credentialed URLs from breaking deduplication. Addresses #1517.

- **Bug Fixes**
  - HTML/RSS/TXT parsers: inject user:pass from the root URL into discovered URLs when hostname and port match; skip if child already has creds.
  - URL utils: domain() now excludes credentials and includes port; added without_auth(); base_url() now ignores credentials so user:pass@host and host dedupe correctly.

<sup>Written for commit 231fb4f10bf0f6513b960721c0a5f0c77fd93a79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

