### PR TITLE
feat: add block-no-verify PreToolUse hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,18 @@
 {
   "enabledPlugins": {
     "pyright-lsp@claude-plugins-official": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as a `PreToolUse` Bash hook. When agents use the hook-bypass flag, it blocks the git command. Closes #1774

---
_Disclosure: I am the author and maintainer of `block-no-verify`._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a PreToolUse hook for Bash in .claude/settings.json to run `npx block-no-verify@1.1.2`. This blocks Git commands that pass `--no-verify`, preventing agents from bypassing hooks.

<sup>Written for commit daf5e8fa5a1103e60c34688e722e2608d022051c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

