### PR TITLE
fix: skip URL entries in save_text_as_source to prevent Path() errors

### DIFF
--- a/archivebox/parsers/__init__.py
+++ b/archivebox/parsers/__init__.py
@@ -155,6 +155,9 @@ def save_text_as_source(raw_text: str, filename: str='{ts}-stdin.txt', out_dir: 
     referenced_texts = ''
 
     for entry in raw_text.split():
+        # Skip URLs - Path() can't handle them and they aren't local files
+        if any(entry.startswith(s) for s in ('http://', 'https://', 'ftp://')):
+            continue
         try:
             if Path(entry).exists():
                 referenced_texts += Path(entry).read_text()


### PR DESCRIPTION
## Fix for Issue #1000

When using `archivebox add --parser=wallabag_atom <feed_url>`, the raw feed URL was being processed by `save_text_as_source()` which splits on whitespace and passes each token to `Path()`. URLs get broken and treated as local file paths, causing spurious "No such file" errors and random file paths to be accessed.

### Root Cause
Commit a676767 added file-referencing logic to `save_text_as_source()`. URLs in the raw text (like wallabag feed URLs) get split into fragments that `Path()` then tries to read as local files.

### Fix
Skip entries that look like URLs (`http://`, `https://`, `ftp://`) before calling `Path().exists()`.

### Testing
Run: `curl <wallabag_feed_url> | archivebox add --parser=wallabag_atom`

Fixes #1000


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip URL tokens (`http://`, `https://`, `ftp://`) in `save_text_as_source()` to avoid passing them to `Path()`, preventing "No such file" errors when adding Wallabag Atom feeds. Fixes #1000.

<sup>Written for commit 5e47e055a2f52cd84ecc697b6929c8fe8b9fe75a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

