### PR TITLE
Remove slug field from Tag model

### DIFF
--- a/archivebox/api/v1_core.py
+++ b/archivebox/api/v1_core.py
@@ -2,7 +2,6 @@ __package__ = "archivebox.api"
 
 import math
 from collections import defaultdict
-from urllib.parse import quote
 from uuid import UUID
 from typing import Union, Any, Annotated
 from datetime import datetime
@@ -37,6 +36,7 @@ from archivebox.core.tag_utils import (
     normalize_has_snapshots_filter,
     normalize_tag_sort,
     rename_tag as rename_tag_record,
+    tag_filename_safe,
 )
 from archivebox.crawls.models import Crawl
 from archivebox.api.v1_crawls import CrawlSchema
@@ -725,8 +725,7 @@ def tag_urls_export(request: HttpRequest, tag_id: int):
         raise HttpError(404, "Tag not found") from err
 
     response = HttpResponse(export_tag_urls(tag), content_type="text/plain; charset=utf-8")
-    # TODO: potentially harden this more, e.g. replace all special characters with ANSII equivalents / strip punctuation / etc.
-    response["Content-Disposition"] = f'attachment; filename="tag-{quote(tag.name, safe="")}-urls.txt"'
+    response["Content-Disposition"] = f'attachment; filename="tag-{tag_filename_safe(tag.name)}-urls.txt"'
     return response
 
 
@@ -738,8 +737,7 @@ def tag_snapshots_export(request: HttpRequest, tag_id: int):
         raise HttpError(404, "Tag not found") from err
 
     response = HttpResponse(export_tag_snapshots_jsonl(tag), content_type="application/x-ndjson; charset=utf-8")
-    # TODO: potentially harden this more, e.g. replace all special characters with ANSII equivalents / strip punctuation / etc.
-    response["Content-Disposition"] = f'attachment; filename="tag-{quote(tag.name, safe="")}-snapshots.jsonl"'
+    response["Content-Disposition"] = f'attachment; filename="tag-{tag_filename_safe(tag.name)}-snapshots.jsonl"'
     return response
 
 

--- a/archivebox/api/v1_core.py
+++ b/archivebox/api/v1_core.py
@@ -725,6 +725,7 @@ def tag_urls_export(request: HttpRequest, tag_id: int):
         raise HttpError(404, "Tag not found") from err
 
     response = HttpResponse(export_tag_urls(tag), content_type="text/plain; charset=utf-8")
+    # TODO: potentially harden this more, e.g. replace all special characters with ANSII equivalents / strip punctuation / etc.
     response["Content-Disposition"] = f'attachment; filename="tag-{quote(tag.name, safe="")}-urls.txt"'
     return response
 
@@ -737,6 +738,7 @@ def tag_snapshots_export(request: HttpRequest, tag_id: int):
         raise HttpError(404, "Tag not found") from err
 
     response = HttpResponse(export_tag_snapshots_jsonl(tag), content_type="application/x-ndjson; charset=utf-8")
+    # TODO: potentially harden this more, e.g. replace all special characters with ANSII equivalents / strip punctuation / etc.
     response["Content-Disposition"] = f'attachment; filename="tag-{quote(tag.name, safe="")}-snapshots.jsonl"'
     return response
 

--- a/archivebox/api/v1_core.py
+++ b/archivebox/api/v1_core.py
@@ -36,7 +36,6 @@ from archivebox.core.tag_utils import (
     normalize_has_snapshots_filter,
     normalize_tag_sort,
     rename_tag as rename_tag_record,
-    tag_filename_safe,
 )
 from archivebox.crawls.models import Crawl
 from archivebox.api.v1_crawls import CrawlSchema
@@ -725,7 +724,7 @@ def tag_urls_export(request: HttpRequest, tag_id: int):
         raise HttpError(404, "Tag not found") from err
 
     response = HttpResponse(export_tag_urls(tag), content_type="text/plain; charset=utf-8")
-    response["Content-Disposition"] = f'attachment; filename="tag-{tag_filename_safe(tag.name)}-urls.txt"'
+    response["Content-Disposition"] = f'attachment; filename="tag-{tag.slug}-urls.txt"'
     return response
 
 
@@ -737,7 +736,7 @@ def tag_snapshots_export(request: HttpRequest, tag_id: int):
         raise HttpError(404, "Tag not found") from err
 
     response = HttpResponse(export_tag_snapshots_jsonl(tag), content_type="application/x-ndjson; charset=utf-8")
-    response["Content-Disposition"] = f'attachment; filename="tag-{tag_filename_safe(tag.name)}-snapshots.jsonl"'
+    response["Content-Disposition"] = f'attachment; filename="tag-{tag.slug}-snapshots.jsonl"'
     return response
 
 

--- a/archivebox/api/v1_core.py
+++ b/archivebox/api/v1_core.py
@@ -554,6 +554,7 @@ class TagSearchSnapshotSchema(Schema):
 class TagSearchCardSchema(Schema):
     id: int
     name: str
+    slug: str
     num_snapshots: int
     filter_url: str
     edit_url: str

--- a/archivebox/api/v1_core.py
+++ b/archivebox/api/v1_core.py
@@ -2,6 +2,7 @@ __package__ = "archivebox.api"
 
 import math
 from collections import defaultdict
+from urllib.parse import quote
 from uuid import UUID
 from typing import Union, Any, Annotated
 from datetime import datetime
@@ -447,7 +448,6 @@ class TagSchema(Schema):
     created_by_id: str
     created_by_username: str
     name: str
-    slug: str
     num_snapshots: int
     snapshots: list[SnapshotSchema]
 
@@ -555,7 +555,6 @@ class TagSearchSnapshotSchema(Schema):
 class TagSearchCardSchema(Schema):
     id: int
     name: str
-    slug: str
     num_snapshots: int
     filter_url: str
     edit_url: str
@@ -582,7 +581,6 @@ class TagUpdateResponseSchema(Schema):
     success: bool
     tag_id: int
     tag_name: str
-    slug: str
 
 
 class TagDeleteResponseSchema(Schema):
@@ -665,7 +663,7 @@ def tags_autocomplete(request: HttpRequest, q: str = ""):
     tags = get_matching_tags(q)[: 50 if not q else 20]
 
     return {
-        "tags": [{"id": tag.pk, "name": tag.name, "slug": tag.slug, "num_snapshots": getattr(tag, "num_snapshots", 0)} for tag in tags],
+        "tags": [{"id": tag.pk, "name": tag.name, "num_snapshots": getattr(tag, "num_snapshots", 0)} for tag in tags],
     }
 
 
@@ -701,7 +699,6 @@ def rename_tag(request: HttpRequest, tag_id: int, data: TagUpdateSchema):
         "success": True,
         "tag_id": tag.pk,
         "tag_name": tag.name,
-        "slug": tag.slug,
     }
 
 
@@ -728,7 +725,7 @@ def tag_urls_export(request: HttpRequest, tag_id: int):
         raise HttpError(404, "Tag not found") from err
 
     response = HttpResponse(export_tag_urls(tag), content_type="text/plain; charset=utf-8")
-    response["Content-Disposition"] = f'attachment; filename="tag-{tag.slug}-urls.txt"'
+    response["Content-Disposition"] = f'attachment; filename="tag-{quote(tag.name, safe="")}-urls.txt"'
     return response
 
 
@@ -740,7 +737,7 @@ def tag_snapshots_export(request: HttpRequest, tag_id: int):
         raise HttpError(404, "Tag not found") from err
 
     response = HttpResponse(export_tag_snapshots_jsonl(tag), content_type="application/x-ndjson; charset=utf-8")
-    response["Content-Disposition"] = f'attachment; filename="tag-{tag.slug}-snapshots.jsonl"'
+    response["Content-Disposition"] = f'attachment; filename="tag-{quote(tag.name, safe="")}-snapshots.jsonl"'
     return response
 
 

--- a/archivebox/core/admin_tags.py
+++ b/archivebox/core/admin_tags.py
@@ -62,8 +62,8 @@ class TagAdmin(BaseModelAdmin):
     change_form_template = "admin/core/tag/change_form.html"
     list_display = ("name", "num_snapshots", "created_at", "created_by")
     list_filter = ("created_at", "created_by")
-    search_fields = ("id", "name", "slug")
-    readonly_fields = ("slug", "id", "created_at", "modified_at", "snapshots")
+    search_fields = ("id", "name")
+    readonly_fields = ("id", "created_at", "modified_at", "snapshots")
     actions = ["delete_selected"]
     ordering = ["name", "id"]
 
@@ -71,7 +71,7 @@ class TagAdmin(BaseModelAdmin):
         (
             "Tag",
             {
-                "fields": ("name", "slug"),
+                "fields": ("name",),
                 "classes": ("card",),
             },
         ),

--- a/archivebox/core/migrations/0034_remove_tag_slug.py
+++ b/archivebox/core/migrations/0034_remove_tag_slug.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0033_alter_archiveresult_status"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="tag",
+            name="slug",
+        ),
+    ]

--- a/archivebox/core/models.py
+++ b/archivebox/core/models.py
@@ -15,7 +15,6 @@ from statemachine import State, registry
 from django.db import models
 from django.db.models import QuerySet
 from django.utils.functional import cached_property
-from django.utils.text import slugify
 from django.utils import timezone
 from django.core.cache import cache
 from django.urls import reverse_lazy
@@ -59,7 +58,6 @@ class Tag(ModelWithUUID):
     created_at = models.DateTimeField(default=timezone.now, db_index=True, null=True)
     modified_at = models.DateTimeField(auto_now=True)
     name = models.CharField(unique=True, blank=False, max_length=100)
-    slug = models.SlugField(unique=True, blank=False, max_length=100, editable=False)
 
     snapshot_set: models.Manager["Snapshot"]
 
@@ -70,42 +68,6 @@ class Tag(ModelWithUUID):
 
     def __str__(self):
         return self.name
-
-    def _generate_unique_slug(self) -> str:
-        base_slug = slugify(self.name) or "tag"
-        existing = Tag.objects.filter(slug__startswith=base_slug)
-        if self.pk:
-            existing = existing.exclude(pk=self.pk)
-        existing_slugs = set(existing.values_list("slug", flat=True))
-
-        slug = base_slug
-        i = 1
-        while slug in existing_slugs:
-            slug = f"{base_slug}_{i}"
-            i += 1
-        return slug
-
-    def save(self, *args, **kwargs):
-        existing_name = None
-        if self.pk:
-            existing_name = Tag.objects.filter(pk=self.pk).values_list("name", flat=True).first()
-
-        if not self.slug or existing_name != self.name:
-            self.slug = self._generate_unique_slug()
-        super().save(*args, **kwargs)
-
-        # if is_new:
-        #     from archivebox.misc.logging_util import log_worker_event
-        #     log_worker_event(
-        #         worker_type='DB',
-        #         event='Created Tag',
-        #         indent_level=0,
-        #         metadata={
-        #             'id': self.id,
-        #             'name': self.name,
-        #             'slug': self.slug,
-        #         },
-        #     )
 
     @property
     def api_url(self) -> str:
@@ -122,7 +84,6 @@ class Tag(ModelWithUUID):
             "schema_version": VERSION,
             "id": str(self.id),
             "name": self.name,
-            "slug": self.slug,
         }
 
     @staticmethod

--- a/archivebox/core/models.py
+++ b/archivebox/core/models.py
@@ -15,6 +15,7 @@ from statemachine import State, registry
 from django.db import models
 from django.db.models import QuerySet
 from django.utils.functional import cached_property
+from django.utils.text import slugify
 from django.utils import timezone
 from django.core.cache import cache
 from django.urls import reverse_lazy
@@ -68,6 +69,11 @@ class Tag(ModelWithUUID):
 
     def __str__(self):
         return self.name
+
+    @property
+    def slug(self) -> str:
+        """ASCII-safe slugified form of the tag name (derived, not stored)."""
+        return slugify(self.name or "") or "tag"
 
     @property
     def api_url(self) -> str:

--- a/archivebox/core/tag_utils.py
+++ b/archivebox/core/tag_utils.py
@@ -10,7 +10,6 @@ from django.db.models import Count, F, QuerySet
 from django.db.models.functions import Lower
 from django.http import HttpRequest
 from django.urls import reverse
-from django.utils.text import slugify
 
 from archivebox.core.host_utils import build_snapshot_url, build_web_url
 from archivebox.core.models import Snapshot, SnapshotTag, Tag
@@ -34,11 +33,6 @@ TAG_HAS_SNAPSHOTS_CHOICES = (
 
 def normalize_tag_name(name: str) -> str:
     return (name or "").strip()
-
-
-def tag_filename_safe(name: str) -> str:
-    """ASCII-safe filename fragment for a tag name (via django.utils.text.slugify)."""
-    return slugify(name or "") or "tag"
 
 
 def normalize_tag_sort(sort: str = "created_desc") -> str:

--- a/archivebox/core/tag_utils.py
+++ b/archivebox/core/tag_utils.py
@@ -230,6 +230,7 @@ def build_tag_card(tag: Tag, snapshot_previews: list[dict[str, Any]] | None = No
     return {
         "id": tag.pk,
         "name": tag.name,
+        "slug": tag.slug,
         "num_snapshots": count,
         "filter_url": f"{reverse('admin:core_snapshot_changelist')}?tags__id__exact={tag.pk}",
         "edit_url": reverse("admin:core_tag_change", args=[tag.pk]),

--- a/archivebox/core/tag_utils.py
+++ b/archivebox/core/tag_utils.py
@@ -10,6 +10,7 @@ from django.db.models import Count, F, QuerySet
 from django.db.models.functions import Lower
 from django.http import HttpRequest
 from django.urls import reverse
+from django.utils.text import slugify
 
 from archivebox.core.host_utils import build_snapshot_url, build_web_url
 from archivebox.core.models import Snapshot, SnapshotTag, Tag
@@ -33,6 +34,11 @@ TAG_HAS_SNAPSHOTS_CHOICES = (
 
 def normalize_tag_name(name: str) -> str:
     return (name or "").strip()
+
+
+def tag_filename_safe(name: str) -> str:
+    """ASCII-safe filename fragment for a tag name (via django.utils.text.slugify)."""
+    return slugify(name or "") or "tag"
 
 
 def normalize_tag_sort(sort: str = "created_desc") -> str:

--- a/archivebox/core/tag_utils.py
+++ b/archivebox/core/tag_utils.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import json
 from collections import defaultdict
 from typing import Any
+from urllib.parse import unquote
 
 from django.contrib.auth.models import User
-from django.db.models import Count, F, Q, QuerySet
+from django.db.models import Count, F, QuerySet
 from django.db.models.functions import Lower
 from django.http import HttpRequest
 from django.urls import reverse
@@ -66,9 +67,7 @@ def get_matching_tags(
 
     query = normalize_tag_name(query)
     if query:
-        queryset = queryset.filter(
-            Q(name__icontains=query) | Q(slug__icontains=query),
-        )
+        queryset = queryset.filter(name__icontains=query)
 
     created_by = normalize_created_by_filter(created_by)
     if created_by:
@@ -124,10 +123,8 @@ def get_tag_by_ref(tag_ref: str | int) -> Tag:
     if ref.isdigit():
         return Tag.objects.get(pk=int(ref))
 
-    try:
-        return Tag.objects.get(slug__iexact=ref)
-    except Tag.DoesNotExist:
-        return Tag.objects.get(slug__icontains=ref)
+    decoded = unquote(ref)
+    return Tag.objects.get(name__iexact=decoded)
 
 
 def get_or_create_tag(name: str, created_by: User | None = None) -> tuple[Tag, bool]:
@@ -233,7 +230,6 @@ def build_tag_card(tag: Tag, snapshot_previews: list[dict[str, Any]] | None = No
     return {
         "id": tag.pk,
         "name": tag.name,
-        "slug": tag.slug,
         "num_snapshots": count,
         "filter_url": f"{reverse('admin:core_snapshot_changelist')}?tags__id__exact={tag.pk}",
         "edit_url": reverse("admin:core_tag_change", args=[tag.pk]),

--- a/archivebox/templates/admin/core/tag/change_form.html
+++ b/archivebox/templates/admin/core/tag/change_form.html
@@ -238,7 +238,7 @@ document.addEventListener('DOMContentLoaded', function () {
             return '' +
                 '<a class="tag-similar-card" href="' + escapeHtml(card.filter_url) + '">' +
                     '<strong>' + escapeHtml(card.name) + '</strong>' +
-                    '<span>' + escapeHtml(card.num_snapshots) + ' snapshots · slug: ' + escapeHtml(card.slug) + '</span>' +
+                    '<span>' + escapeHtml(card.num_snapshots) + ' snapshots</span>' +
                     '<div class="tag-similar-card__snapshots">' + (snapshots || '<span class="tag-similar-snapshot">No snapshots</span>') + '</div>' +
                 '</a>';
         }).join('');

--- a/archivebox/templates/admin/core/tag/change_list.html
+++ b/archivebox/templates/admin/core/tag/change_list.html
@@ -974,8 +974,7 @@ document.addEventListener('DOMContentLoaded', function () {
         if (action === 'download-jsonl') {
             actionButton.disabled = true;
             try {
-                const tagName = cardEl.querySelector('.tag-card__display strong')?.textContent || 'tag';
-                await downloadFileFromUrl(cardEl.dataset.exportJsonlUrl, 'tag-' + encodeURIComponent(tagName) + '-snapshots.jsonl');
+                await downloadFileFromUrl(cardEl.dataset.exportJsonlUrl, 'tag-snapshots.jsonl');
             } catch (error) {
                 setToast(error.message || 'Failed to download JSONL.', 'error');
             } finally {

--- a/archivebox/templates/admin/core/tag/change_list.html
+++ b/archivebox/templates/admin/core/tag/change_list.html
@@ -551,14 +551,6 @@ document.addEventListener('DOMContentLoaded', function () {
         return div.innerHTML;
     }
 
-    function slugify(value) {
-        return String(value || '')
-            .toLowerCase()
-            .trim()
-            .replace(/[^a-z0-9]+/g, '-')
-            .replace(/^-+|-+$/g, '') || 'tag';
-    }
-
     function getCSRFToken() {
         const input = document.querySelector('input[name="csrfmiddlewaretoken"]');
         if (input) return input.value;
@@ -983,7 +975,7 @@ document.addEventListener('DOMContentLoaded', function () {
             actionButton.disabled = true;
             try {
                 const tagName = cardEl.querySelector('.tag-card__display strong')?.textContent || 'tag';
-                await downloadFileFromUrl(cardEl.dataset.exportJsonlUrl, 'tag-' + slugify(tagName) + '-snapshots.jsonl');
+                await downloadFileFromUrl(cardEl.dataset.exportJsonlUrl, 'tag-' + encodeURIComponent(tagName) + '-snapshots.jsonl');
             } catch (error) {
                 setToast(error.message || 'Failed to download JSONL.', 'error');
             } finally {

--- a/archivebox/templates/admin/core/tag/change_list.html
+++ b/archivebox/templates/admin/core/tag/change_list.html
@@ -476,6 +476,7 @@
                     <article
                         class="tag-card"
                         data-id="{{ card.id }}"
+                        data-slug="{{ card.slug }}"
                         data-filter-url="{{ card.filter_url }}"
                         data-rename-url="{{ card.rename_url }}"
                         data-delete-url="{{ card.delete_url }}"
@@ -666,7 +667,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 : '<div class="tag-card__empty">No snapshots attached yet.</div>';
 
             return '' +
-                '<article class="tag-card" data-id="' + escapeHtml(card.id) + '" data-filter-url="' + escapeHtml(card.filter_url) + '" data-rename-url="' + escapeHtml(card.rename_url) + '" data-delete-url="' + escapeHtml(card.delete_url) + '" data-export-urls-url="' + escapeHtml(card.export_urls_url) + '" data-export-jsonl-url="' + escapeHtml(card.export_jsonl_url) + '">' +
+                '<article class="tag-card" data-id="' + escapeHtml(card.id) + '" data-slug="' + escapeHtml(card.slug) + '" data-filter-url="' + escapeHtml(card.filter_url) + '" data-rename-url="' + escapeHtml(card.rename_url) + '" data-delete-url="' + escapeHtml(card.delete_url) + '" data-export-urls-url="' + escapeHtml(card.export_urls_url) + '" data-export-jsonl-url="' + escapeHtml(card.export_jsonl_url) + '">' +
                     '<div class="tag-card__header">' +
                         '<div class="tag-card__title">' +
                             '<div class="tag-card__display">' +
@@ -974,7 +975,8 @@ document.addEventListener('DOMContentLoaded', function () {
         if (action === 'download-jsonl') {
             actionButton.disabled = true;
             try {
-                await downloadFileFromUrl(cardEl.dataset.exportJsonlUrl, 'tag-snapshots.jsonl');
+                const tagSlug = cardEl.dataset.slug || 'tag';
+                await downloadFileFromUrl(cardEl.dataset.exportJsonlUrl, 'tag-' + tagSlug + '-snapshots.jsonl');
             } catch (error) {
                 setToast(error.message || 'Failed to download JSONL.', 'error');
             } finally {

--- a/archivebox/tests/test_migrations_fresh.py
+++ b/archivebox/tests/test_migrations_fresh.py
@@ -197,7 +197,7 @@ class TestSchemaIntegrity(unittest.TestCase):
             columns = {row[1] for row in cursor.fetchall()}
             conn.close()
 
-            required = {"id", "name", "slug"}
+            required = {"id", "name"}
             for col in required:
                 self.assertIn(col, columns, f"Missing column: {col}")
 

--- a/archivebox/tests/test_tag_admin.py
+++ b/archivebox/tests/test_tag_admin.py
@@ -179,11 +179,9 @@ def test_tag_snapshots_export_returns_jsonl(client, api_token, tagged_data):
         HTTP_HOST=ADMIN_HOST,
     )
 
-    from archivebox.core.tag_utils import tag_filename_safe
-
     assert response.status_code == 200
     assert response["Content-Type"].startswith("application/x-ndjson")
-    assert f"tag-{tag_filename_safe(tag.name)}-snapshots.jsonl" in response["Content-Disposition"]
+    assert f"tag-{tag.slug}-snapshots.jsonl" in response["Content-Disposition"]
     body = response.content.decode()
     assert '"type": "Snapshot"' in body
     assert '"tags": "Alpha Research"' in body
@@ -198,10 +196,8 @@ def test_tag_urls_export_returns_plain_text_urls(client, api_token, tagged_data)
         HTTP_HOST=ADMIN_HOST,
     )
 
-    from archivebox.core.tag_utils import tag_filename_safe
-
     assert response.status_code == 200
     assert response["Content-Type"].startswith("text/plain")
-    assert f"tag-{tag_filename_safe(tag.name)}-urls.txt" in response["Content-Disposition"]
+    assert f"tag-{tag.slug}-urls.txt" in response["Content-Disposition"]
     exported_urls = set(filter(None, response.content.decode().splitlines()))
     assert exported_urls == {snapshot.url for snapshot in snapshots}

--- a/archivebox/tests/test_tag_admin.py
+++ b/archivebox/tests/test_tag_admin.py
@@ -179,11 +179,11 @@ def test_tag_snapshots_export_returns_jsonl(client, api_token, tagged_data):
         HTTP_HOST=ADMIN_HOST,
     )
 
-    from urllib.parse import quote
+    from archivebox.core.tag_utils import tag_filename_safe
 
     assert response.status_code == 200
     assert response["Content-Type"].startswith("application/x-ndjson")
-    assert f"tag-{quote(tag.name, safe='')}-snapshots.jsonl" in response["Content-Disposition"]
+    assert f"tag-{tag_filename_safe(tag.name)}-snapshots.jsonl" in response["Content-Disposition"]
     body = response.content.decode()
     assert '"type": "Snapshot"' in body
     assert '"tags": "Alpha Research"' in body
@@ -198,10 +198,10 @@ def test_tag_urls_export_returns_plain_text_urls(client, api_token, tagged_data)
         HTTP_HOST=ADMIN_HOST,
     )
 
-    from urllib.parse import quote
+    from archivebox.core.tag_utils import tag_filename_safe
 
     assert response.status_code == 200
     assert response["Content-Type"].startswith("text/plain")
-    assert f"tag-{quote(tag.name, safe='')}-urls.txt" in response["Content-Disposition"]
+    assert f"tag-{tag_filename_safe(tag.name)}-urls.txt" in response["Content-Disposition"]
     exported_urls = set(filter(None, response.content.decode().splitlines()))
     assert exported_urls == {snapshot.url for snapshot in snapshots}

--- a/archivebox/tests/test_tag_admin.py
+++ b/archivebox/tests/test_tag_admin.py
@@ -154,7 +154,7 @@ def test_tag_search_api_respects_sort_and_filters(client, api_token, admin_user,
     assert [tag["name"] for tag in payload["tags"]] == ["Zulu Empty"]
 
 
-def test_tag_rename_api_updates_slug(client, api_token, tagged_data):
+def test_tag_rename_api_updates_name(client, api_token, tagged_data):
     tag, _ = tagged_data
 
     response = client.post(
@@ -168,7 +168,6 @@ def test_tag_rename_api_updates_slug(client, api_token, tagged_data):
 
     tag.refresh_from_db()
     assert tag.name == "Alpha Archive"
-    assert tag.slug == "alpha-archive"
 
 
 def test_tag_snapshots_export_returns_jsonl(client, api_token, tagged_data):
@@ -180,9 +179,11 @@ def test_tag_snapshots_export_returns_jsonl(client, api_token, tagged_data):
         HTTP_HOST=ADMIN_HOST,
     )
 
+    from urllib.parse import quote
+
     assert response.status_code == 200
     assert response["Content-Type"].startswith("application/x-ndjson")
-    assert f"tag-{tag.slug}-snapshots.jsonl" in response["Content-Disposition"]
+    assert f"tag-{quote(tag.name, safe='')}-snapshots.jsonl" in response["Content-Disposition"]
     body = response.content.decode()
     assert '"type": "Snapshot"' in body
     assert '"tags": "Alpha Research"' in body
@@ -197,8 +198,10 @@ def test_tag_urls_export_returns_plain_text_urls(client, api_token, tagged_data)
         HTTP_HOST=ADMIN_HOST,
     )
 
+    from urllib.parse import quote
+
     assert response.status_code == 200
     assert response["Content-Type"].startswith("text/plain")
-    assert f"tag-{tag.slug}-urls.txt" in response["Content-Disposition"]
+    assert f"tag-{quote(tag.name, safe='')}-urls.txt" in response["Content-Disposition"]
     exported_urls = set(filter(None, response.content.decode().splitlines()))
     assert exported_urls == {snapshot.url for snapshot in snapshots}


### PR DESCRIPTION
## Summary

This PR removes the `slug` field from the Tag model and all related slug generation logic. Tags are now identified and referenced by their name instead of a generated slug, simplifying the data model and reducing complexity.

## Related issues

N/A

## Changes these areas

- [x] Internal architecture
- [x] Snapshot data layout on disk

## Details

### What changed

1. **Model changes**: Removed the `slug` field from the Tag model, including the `_generate_unique_slug()` method and slug generation logic in the `save()` method
2. **Database migration**: Added migration `0034_remove_tag_slug` to drop the slug column
3. **API updates**: Removed `slug` from all API schemas (TagSchema, TagSearchCardSchema, TagUpdateResponseSchema) and responses
4. **Tag lookup**: Updated `get_tag_by_ref()` to use URL-decoded tag names instead of slugs for lookups
5. **Tag filtering**: Simplified `get_matching_tags()` to only filter by name instead of both name and slug
6. **Export filenames**: Changed tag export filenames to use `quote(tag.name)` instead of `tag.slug`
7. **Admin interface**: Removed slug from TagAdmin search fields, readonly fields, and fieldsets
8. **Templates**: Removed slug display from tag cards and similar tags UI
9. **Tests**: Updated test expectations and removed slug assertions; updated export filename checks to use `quote(tag.name)`

### Why

This simplifies the Tag model by removing the derived slug field. Tags can be uniquely identified by their name, and URL encoding handles special characters in filenames and URLs. This reduces database complexity and eliminates the need for slug generation and uniqueness logic.

## Test Plan

Existing tests have been updated to verify the new behavior:
- `test_tag_rename_api_updates_name` verifies tag renaming works without slug
- `test_tag_snapshots_export_returns_jsonl` and `test_tag_urls_export_returns_plain_text_urls` verify export filenames use encoded tag names
- `test_tag_table_has_required_columns` verifies the database schema no longer includes slug

All related tests pass with the updated assertions.

https://claude.ai/code/session_014KmEXoA64Ayp2t8BW2xfVP
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/archivebox/archivebox/pull/1789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the stored `slug` from Tag and moved to name-based tags. Added a derived `Tag.slug` via `django.utils.text.slugify` for clean export filenames and an admin download fallback; public APIs no longer include slugs and lookups resolve by URL-decoded exact name.

- **Refactors**
  - Replaced stored slug with a derived `Tag.slug` property; removed slug generation/save logic.
  - Public API schemas and autocomplete drop `slug`; matching/filtering uses `name` only.
  - `get_tag_by_ref` resolves by URL-decoded `name` (case-insensitive exact match).
  - Export endpoints set filenames using `tag.slug`; admin tag cards expose `data-slug`, and the client uses it as a fallback filename. Removed slug from admin search fields/fieldsets and UI displays.

- **Migration**
  - Run database migrations.
  - Update any consumers expecting `slug` in Tag API/admin; use the tag `name` for references (URL-encode names in links). Rely on server-provided filenames, with the built-in client fallback using `tag.slug` where needed.

<sup>Written for commit 7c3a3e0dba0e1a845289926a834255a54420d148. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

