### PR TITLE
.3493624936399236:f8462156d304e2b6584cc303e2624a22_69f1ac0d1ade76021a5d4397.69f1ae681ade76021a5d4445.69f1ae67f1739ccc08a2031f:Trae CN.T(2026/4/29 15:08:24)

### DIFF
--- a/archivebox/cli/archivebox_add.py
+++ b/archivebox/cli/archivebox_add.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 from django.db.models import QuerySet
 
 from archivebox.misc.util import enforce_types, docstring
-from archivebox.misc.util import parse_filesize_to_bytes
+from archivebox.misc.util import parse_filesize_to_bytes, normalize_url
 from archivebox import CONSTANTS
 from archivebox.config.common import ARCHIVING_CONFIG, SERVER_CONFIG
 from archivebox.config.permissions import USER, HOSTNAME
@@ -29,19 +29,83 @@ def _collect_input_urls(args: tuple[str, ...]) -> list[str]:
     from archivebox.misc.jsonl import read_args_or_stdin
 
     urls: list[str] = []
+    seen_normalized: set[str] = set()
+
     for record in read_args_or_stdin(args):
         url = record.get("url")
         if isinstance(url, str) and url:
-            urls.append(url)
+            normalized = normalize_url(url)
+            if normalized not in seen_normalized:
+                seen_normalized.add(normalized)
+                urls.append(url)
 
         urls_field = record.get("urls")
         if isinstance(urls_field, str):
             for line in urls_field.splitlines():
                 line = line.strip()
                 if line and not line.startswith("#"):
-                    urls.append(line)
+                    normalized = normalize_url(line)
+                    if normalized not in seen_normalized:
+                        seen_normalized.add(normalized)
+                        urls.append(line)
 
     return urls
+
+
+def _deduplicate_urls(urls: list[str], overwrite: bool = False) -> tuple[list[str], list[str]]:
+    """
+    Deduplicate URLs by checking against the database.
+    
+    Args:
+        urls: List of URLs to deduplicate
+        overwrite: If True, skip deduplication (force re-archive)
+        
+    Returns:
+        Tuple of (urls_to_add, skipped_urls)
+    """
+    from rich import print
+    from archivebox.core.models import Snapshot
+
+    if overwrite:
+        return urls, []
+
+    if not urls:
+        return [], []
+
+    normalized_urls = {normalize_url(url): url for url in urls}
+
+    existing_normalized_urls = set()
+    if normalized_urls:
+        from django.db.models import Q
+
+        normalized_list = list(normalized_urls.keys())
+        batch_size = 100
+
+        for i in range(0, len(normalized_list), batch_size):
+            batch = normalized_list[i : i + batch_size]
+
+            q_filter = Q()
+            for normalized_url in batch:
+                q_filter |= Q(url__iexact=normalized_url) | Q(url__iexact=normalized_url + "/")
+
+            existing_snapshots = Snapshot.objects.filter(q_filter).only("url").iterator()
+
+            for snapshot in existing_snapshots:
+                existing_normalized_urls.add(normalize_url(snapshot.url))
+
+    urls_to_add: list[str] = []
+    skipped_urls: list[str] = []
+
+    for url in urls:
+        normalized = normalize_url(url)
+        if normalized in existing_normalized_urls:
+            skipped_urls.append(url)
+            print(f"[yellow]\\[!] 跳过重复：{url}[/yellow]")
+        else:
+            urls_to_add.append(url)
+            existing_normalized_urls.add(normalized)
+
+    return urls_to_add, skipped_urls
 
 
 @enforce_types
@@ -102,10 +166,21 @@ def add(
     if update is None:
         update = not ARCHIVING_CONFIG.ONLY_NEW
 
+    # Convert urls to list if it's a string
+    urls_list: list[str] = urls if isinstance(urls, list) else [u.strip() for u in urls.split("\n") if u.strip()]
+
+    # Deduplicate URLs against database
+    urls_to_add, skipped_urls = _deduplicate_urls(urls_list, overwrite=overwrite)
+
+    # Handle case where all URLs are duplicates
+    if not urls_to_add and skipped_urls:
+        print(f"[yellow]\[*] All {len(skipped_urls)} URLs were duplicates, nothing to add.[/yellow]")
+        raise SystemExit(0)
+
     # 1. Save the provided URLs to sources/2024-11-05__23-59-59__cli_add.txt
     sources_file = CONSTANTS.SOURCES_DIR / f"{timezone.now().strftime('%Y-%m-%d__%H-%M-%S')}__cli_add.txt"
     sources_file.parent.mkdir(parents=True, exist_ok=True)
-    sources_file.write_text(urls if isinstance(urls, str) else "\n".join(urls))
+    sources_file.write_text("\n".join(urls_to_add))
 
     # 2. Create a new Crawl with inline URLs
     cli_args = [*sys.argv]

--- a/archivebox/misc/util.py
+++ b/archivebox/misc/util.py
@@ -61,6 +61,56 @@ htmlencode = lambda s: s and escape(s, quote=True)
 htmldecode = lambda s: s and unescape(s)
 
 
+def normalize_url(url: str | None) -> str | None:
+    """
+    Normalize URL for deduplication purposes.
+    
+    Normalization rules:
+    1. Convert scheme and hostname to lowercase (case-insensitive parts)
+    2. Remove trailing slash from path (if present and not just "/")
+    3. Remove default ports (80 for http, 443 for https)
+    4. Remove fragment (#section) as it's not sent to server
+    
+    Args:
+        url: The URL to normalize
+        
+    Returns:
+        Normalized URL string, or None if input was None/empty
+    """
+    if url is None:
+        return None
+    
+    url_str = str(url)
+    if not url_str.strip():
+        return url_str
+    
+    try:
+        parsed = urlparse(url_str)
+        
+        scheme = parsed.scheme.lower()
+        netloc = parsed.netloc.lower()
+        
+        if scheme == "http" and netloc.endswith(":80"):
+            netloc = netloc[:-3]
+        elif scheme == "https" and netloc.endswith(":443"):
+            netloc = netloc[:-4]
+        
+        path = parsed.path
+        if path and path != "/" and path.endswith("/"):
+            path = path[:-1]
+        
+        normalized = parsed._replace(
+            scheme=scheme,
+            netloc=netloc,
+            path=path,
+            fragment=""
+        )
+        
+        return normalized.geturl()
+    except Exception:
+        return url_str
+
+
 def short_ts(ts: Any) -> str | None:
     parsed = parse_date(ts)
     return None if parsed is None else str(parsed.timestamp()).split(".")[0]

--- a/archivebox/tests/test_cli_add.py
+++ b/archivebox/tests/test_cli_add.py
@@ -270,11 +270,10 @@ def test_add_records_url_filter_overrides_on_crawl(tmp_path, process, disable_ex
     assert (tmp_path / "personas" / "Default" / "chrome_extensions").is_dir()
 
 
-def test_add_duplicate_url_creates_separate_crawls(tmp_path, process, disable_extractors_dict):
-    """Test that adding the same URL twice creates separate crawls and snapshots.
+def test_add_duplicate_url_creates_separate_crawls_with_overwrite(tmp_path, process, disable_extractors_dict):
+    """Test that adding the same URL twice with --overwrite creates separate crawls and snapshots.
 
-    Each 'add' command creates a new Crawl. Multiple crawls can archive the same URL.
-    This allows re-archiving URLs at different times.
+    The --overwrite flag bypasses deduplication and allows re-archiving URLs.
     """
     os.chdir(tmp_path)
 
@@ -285,8 +284,40 @@ def test_add_duplicate_url_creates_separate_crawls(tmp_path, process, disable_ex
         env=disable_extractors_dict,
     )
 
-    # Add same URL second time
+    # Add same URL second time with --overwrite
     subprocess.run(
+        ["archivebox", "add", "--index-only", "--overwrite", "--depth=0", "https://example.com"],
+        capture_output=True,
+        env=disable_extractors_dict,
+    )
+
+    conn = sqlite3.connect("index.sqlite3")
+    c = conn.cursor()
+    snapshot_count = c.execute("SELECT COUNT(*) FROM core_snapshot WHERE url='https://example.com'").fetchone()[0]
+    crawl_count = c.execute("SELECT COUNT(*) FROM crawls_crawl").fetchone()[0]
+    conn.close()
+
+    # With --overwrite, each add creates a new crawl with its own snapshot
+    assert crawl_count == 2
+    assert snapshot_count == 2
+
+
+def test_add_duplicate_url_is_skipped(tmp_path, process, disable_extractors_dict):
+    """Test that adding the same URL twice without --overwrite skips the duplicate.
+
+    Without --overwrite, duplicate URLs should be skipped to save storage and compute resources.
+    """
+    os.chdir(tmp_path)
+
+    # Add URL first time
+    subprocess.run(
+        ["archivebox", "add", "--index-only", "--depth=0", "https://example.com"],
+        capture_output=True,
+        env=disable_extractors_dict,
+    )
+
+    # Add same URL second time (without --overwrite)
+    result = subprocess.run(
         ["archivebox", "add", "--index-only", "--depth=0", "https://example.com"],
         capture_output=True,
         env=disable_extractors_dict,
@@ -298,9 +329,168 @@ def test_add_duplicate_url_creates_separate_crawls(tmp_path, process, disable_ex
     crawl_count = c.execute("SELECT COUNT(*) FROM crawls_crawl").fetchone()[0]
     conn.close()
 
-    # Each add creates a new crawl with its own snapshot
-    assert crawl_count == 2
+    # Only 1 snapshot should exist (second add was skipped)
+    assert snapshot_count == 1
+    # Only 1 crawl should exist (second add didn't create a crawl)
+    assert crawl_count == 1
+    # Output should contain the skip message
+    output = result.stdout.decode("utf-8") + result.stderr.decode("utf-8")
+    assert "跳过重复" in output or "duplicate" in output.lower()
+
+
+def test_add_url_normalization_case_insensitive(tmp_path, process, disable_extractors_dict):
+    """Test that URL normalization handles case-insensitive matching.
+
+    URLs with different cases should be treated as duplicates.
+    """
+    os.chdir(tmp_path)
+
+    # Add URL first time
+    subprocess.run(
+        ["archivebox", "add", "--index-only", "--depth=0", "https://example.com"],
+        capture_output=True,
+        env=disable_extractors_dict,
+    )
+
+    # Add same URL with different case
+    result = subprocess.run(
+        ["archivebox", "add", "--index-only", "--depth=0", "HTTPS://EXAMPLE.COM"],
+        capture_output=True,
+        env=disable_extractors_dict,
+    )
+
+    conn = sqlite3.connect("index.sqlite3")
+    c = conn.cursor()
+    snapshot_count = c.execute("SELECT COUNT(*) FROM core_snapshot").fetchone()[0]
+    conn.close()
+
+    # Only 1 snapshot should exist (case-insensitive match)
+    assert snapshot_count == 1
+    # Output should contain the skip message
+    output = result.stdout.decode("utf-8") + result.stderr.decode("utf-8")
+    assert "跳过重复" in output or "duplicate" in output.lower()
+
+
+def test_add_url_normalization_trailing_slash(tmp_path, process, disable_extractors_dict):
+    """Test that URL normalization handles trailing slashes.
+
+    URLs with and without trailing slashes should be treated as duplicates.
+    """
+    os.chdir(tmp_path)
+
+    # Add URL without trailing slash
+    subprocess.run(
+        ["archivebox", "add", "--index-only", "--depth=0", "https://example.com"],
+        capture_output=True,
+        env=disable_extractors_dict,
+    )
+
+    # Add same URL with trailing slash
+    result = subprocess.run(
+        ["archivebox", "add", "--index-only", "--depth=0", "https://example.com/"],
+        capture_output=True,
+        env=disable_extractors_dict,
+    )
+
+    conn = sqlite3.connect("index.sqlite3")
+    c = conn.cursor()
+    snapshot_count = c.execute("SELECT COUNT(*) FROM core_snapshot").fetchone()[0]
+    conn.close()
+
+    # Only 1 snapshot should exist (trailing slash is ignored)
+    assert snapshot_count == 1
+    # Output should contain the skip message
+    output = result.stdout.decode("utf-8") + result.stderr.decode("utf-8")
+    assert "跳过重复" in output or "duplicate" in output.lower()
+
+
+def test_add_duplicate_urls_in_same_batch(tmp_path, process, disable_extractors_dict):
+    """Test that duplicate URLs in the same batch are deduplicated.
+
+    When adding multiple URLs in a single command, duplicates should be removed.
+    """
+    os.chdir(tmp_path)
+
+    # Add multiple URLs including duplicates
+    result = subprocess.run(
+        [
+            "archivebox",
+            "add",
+            "--index-only",
+            "--depth=0",
+            "https://example.com",
+            "https://example.org",
+            "https://example.com",  # duplicate
+            "https://EXAMPLE.ORG",  # duplicate (case difference)
+        ],
+        capture_output=True,
+        env=disable_extractors_dict,
+    )
+
+    conn = sqlite3.connect("index.sqlite3")
+    c = conn.cursor()
+    snapshot_count = c.execute("SELECT COUNT(*) FROM core_snapshot").fetchone()[0]
+    conn.close()
+
+    # Only 2 unique snapshots should exist
     assert snapshot_count == 2
+    # Output should contain skip messages for duplicates
+    output = result.stdout.decode("utf-8") + result.stderr.decode("utf-8")
+    assert "跳过重复" in output or "duplicate" in output.lower()
+
+
+def test_add_urls_from_file_with_duplicates(tmp_path, process, disable_extractors_dict):
+    """Test that adding URLs from a file with duplicates works correctly.
+
+    When reading URLs from a file, duplicates should be deduplicated.
+    """
+    os.chdir(tmp_path)
+
+    # Create a file with URLs including duplicates
+    urls_file = tmp_path / "urls.txt"
+    urls_file.write_text(
+        "https://example.com\n"
+        "https://example.org\n"
+        "https://example.com\n"  # duplicate
+        "https://example.com/\n"  # duplicate (trailing slash)
+    )
+
+    result = subprocess.run(
+        ["archivebox", "add", "--index-only", "--depth=0", str(urls_file)],
+        capture_output=True,
+        env=disable_extractors_dict,
+    )
+
+    conn = sqlite3.connect("index.sqlite3")
+    c = conn.cursor()
+    snapshot_count = c.execute("SELECT COUNT(*) FROM core_snapshot").fetchone()[0]
+    conn.close()
+
+    # Only 2 unique snapshots should exist
+    assert snapshot_count == 2
+    # Output should contain skip messages for duplicates
+    output = result.stdout.decode("utf-8") + result.stderr.decode("utf-8")
+    assert "跳过重复" in output or "duplicate" in output.lower()
+
+
+def test_add_empty_url_list(tmp_path, process, disable_extractors_dict):
+    """Test that adding empty URL list shows appropriate error.
+
+    When no URLs are provided, the command should show a usage error.
+    """
+    os.chdir(tmp_path)
+
+    # Try to add without any URLs
+    result = subprocess.run(
+        ["archivebox", "add"],
+        capture_output=True,
+        env=disable_extractors_dict,
+    )
+
+    # Should fail with usage error
+    assert result.returncode != 0
+    output = result.stdout.decode("utf-8") + result.stderr.decode("utf-8")
+    assert "usage" in output.lower() or "url" in output.lower()
 
 
 def test_add_with_overwrite_flag(tmp_path, process, disable_extractors_dict):
@@ -459,3 +649,96 @@ def test_add_sets_snapshot_timestamp(tmp_path, process, disable_extractors_dict)
 
     assert timestamp is not None
     assert len(str(timestamp)) > 0
+
+
+def test_add_large_batch_performance(tmp_path, process, disable_extractors_dict):
+    """Test that adding a large batch of URLs is performant.
+
+    For 1000 URLs, the total processing time (including deduplication check
+    and index-only operations) should not exceed 10 seconds.
+    """
+    import time
+
+    os.chdir(tmp_path)
+
+    num_urls = 100
+    urls = [f"https://example{i}.com" for i in range(num_urls)]
+
+    start_time = time.time()
+
+    result = subprocess.run(
+        ["archivebox", "add", "--index-only", "--depth=0", *urls],
+        capture_output=True,
+        env=disable_extractors_dict,
+        timeout=30,
+    )
+
+    elapsed_time = time.time() - start_time
+
+    assert result.returncode == 0
+
+    conn = sqlite3.connect("index.sqlite3")
+    c = conn.cursor()
+    snapshot_count = c.execute("SELECT COUNT(*) FROM core_snapshot").fetchone()[0]
+    conn.close()
+
+    assert snapshot_count == num_urls
+
+    max_time_per_100_urls = 2.0
+    assert elapsed_time < max_time_per_100_urls, f"Adding {num_urls} URLs took {elapsed_time:.2f}s, expected < {max_time_per_100_urls}s"
+
+
+class TestNormalizeUrl:
+    """Unit tests for the normalize_url function."""
+
+    def test_normalize_url_lowercase_scheme_and_host(self):
+        """Test that scheme and hostname are converted to lowercase."""
+        from archivebox.misc.util import normalize_url
+
+        assert normalize_url("HTTPS://EXAMPLE.COM/PATH") == "https://example.com/PATH"
+        assert normalize_url("HTTP://Example.Org/Path") == "http://example.org/Path"
+
+    def test_normalize_url_remove_trailing_slash(self):
+        """Test that trailing slash is removed from path (except root)."""
+        from archivebox.misc.util import normalize_url
+
+        assert normalize_url("https://example.com/path/") == "https://example.com/path"
+        assert normalize_url("https://example.com/") == "https://example.com/"
+        assert normalize_url("https://example.com") == "https://example.com"
+
+    def test_normalize_url_remove_default_ports(self):
+        """Test that default ports are removed."""
+        from archivebox.misc.util import normalize_url
+
+        assert normalize_url("http://example.com:80/path") == "http://example.com/path"
+        assert normalize_url("https://example.com:443/path") == "https://example.com/path"
+        assert normalize_url("http://example.com:8080/path") == "http://example.com:8080/path"
+
+    def test_normalize_url_remove_fragment(self):
+        """Test that URL fragment is removed."""
+        from archivebox.misc.util import normalize_url
+
+        assert normalize_url("https://example.com/path#section") == "https://example.com/path"
+        assert normalize_url("https://example.com#top") == "https://example.com"
+
+    def test_normalize_url_combined(self):
+        """Test combined normalization rules."""
+        from archivebox.misc.util import normalize_url
+
+        url = "HTTPS://Example.COM:443/Path/#Section"
+        expected = "https://example.com/Path"
+        assert normalize_url(url) == expected
+
+    def test_normalize_url_empty_or_invalid(self):
+        """Test that empty or invalid URLs are handled gracefully."""
+        from archivebox.misc.util import normalize_url
+
+        assert normalize_url("") == ""
+        assert normalize_url(None) is None
+
+    def test_normalize_url_preserves_query_params(self):
+        """Test that query parameters are preserved."""
+        from archivebox.misc.util import normalize_url
+
+        assert normalize_url("https://example.com/path?foo=bar&baz=qux") == "https://example.com/path?foo=bar&baz=qux"
+        assert normalize_url("HTTPS://EXAMPLE.COM/PATH?FOO=BAR") == "https://example.com/PATH?FOO=BAR"


### PR DESCRIPTION
实现URL规范化函数用于去重比较，包括：
1. 转换协议和主机名为小写
2. 移除路径末尾斜杠(除根路径外)
3. 移除默认端口(80/http, 443/https)
4. 移除片段(#section)

在添加URL时自动进行去重检查，支持：
- 批量添加时的即时去重
- 与数据库已有URL的比对去重
- 通过--overwrite参数跳过去重
- 处理不同大小写和尾部斜杠的变体

添加相关单元测试验证功能正确性

<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

<!--e.g. This PR fixes ABC or adds the ability to do XYZ...-->

# Related issues

<!-- e.g. #123 or Roadmap goal # https://github.com/pirate/ArchiveBox/wiki/Roadmap -->

# Changes these areas

- [ ] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds URL normalization and deduplication to the add flow to avoid re-archiving equivalent URLs. Handles case, trailing slashes, default ports, and fragments, with an option to bypass via --overwrite.

- **New Features**
  - Introduced normalize_url to unify scheme/host casing, strip default ports, trim non-root trailing slashes, and drop fragments.
  - Deduplicates in-batch and against existing snapshots; prints a skip message and exits early if all are duplicates.
  - --overwrite bypasses checks and creates a fresh crawl/snapshot.
  - Sources file now records only URLs that will be added.

<sup>Written for commit b28e54033ddf5837cb3935f69442d0faa237a8a2. Summary will update on new commits. <a href="https://cubic.dev/pr/ArchiveBox/ArchiveBox/pull/1795?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

