### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Usage:
 #     mkdir -p ~/archivebox/data && cd ~/archivebox
 #     curl -fsSL 'https://docker-compose.archivebox.io' > docker-compose.yml
-#     docker compose run archivebox init --install
+#     docker compose run archivebox init
 #     docker compose run archivebox add --depth=1 'https://news.ycombinator.com'
 #     docker compose run -T archivebox add < bookmarks.txt
 #     docker compose up -d && open 'http://web.archivebox.localhost:8000'
@@ -11,13 +11,12 @@
 
 services:
     archivebox:
-        image: ${ARCHIVEBOX_IMAGE:-archivebox/archivebox:latest}
-        platform: linux/amd64
+        image: ${ARCHIVEBOX_IMAGE:-archivebox/archivebox:dev}
+        # platform: linux/amd64
         ports:
             - 8000:8000
         volumes:
             - ./data:/data
-            # ./data/personas/Default/chrome_profile/Default:/data/personas/Default/chrome_profile/Default
         environment:
             # - ADMIN_USERNAME=admin            # creates an admin user on first run with the given user/pass combo
             # - ADMIN_PASSWORD=SomeSecretPassword
@@ -27,20 +26,6 @@ services:
             - PUBLIC_INDEX=True                 # set to False to prevent anonymous users from viewing snapshot list
             - PUBLIC_SNAPSHOTS=True             # set to False to prevent anonymous users from viewing snapshot content
             - PUBLIC_ADD_VIEW=False             # set to True to allow anonymous users to submit new URLs to archive
-            - SEARCH_BACKEND_ENGINE=sonic       # tells ArchiveBox to use its built-in Sonic worker for fast full-text search
-            # - SEARCH_BACKEND_HOST_NAME=127.0.0.1
-            - SEARCH_BACKEND_PASSWORD=SomeSecretPassword
-            - PERSONAS_DIR=/data/personas
-            - LIB_DIR=/data/lib
-            - NODE_PATH=/home/archivebox/.npm/lib/node_modules:/usr/lib/node_modules:/data/lib/npm/node_modules:/usr/share/archivebox/lib/npm/node_modules:/data/personas/Default/node_modules
-            - PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable
-            - CHROME_BIN=/usr/bin/google-chrome-stable
-            - CHROME_BINARY=/usr/bin/google-chrome-stable
-            - CHROME_USER_DATA_DIR=/data/personas/Default/chrome_profile
-            - CHROME_HEADLESS=true
-            - CHROME_SANDBOX=false
-            - CHROME_ISOLATION=crawl
-            - CHROME_ARGS_EXTRA=["--disable-gpu","--disable-features=Translate,OptimizationGuideModelDownloading,MediaRouter"]
             # - PUID=911                        # set to your host user's UID & GID if you encounter permissions issues
             # - PGID=911                        # UID/GIDs lower than 500 may clash with system uids and are not recommended
             # For options below, it's better to set in data/ArchiveBox.conf or use `docker compose run archivebox config --set SOME_KEY=someval` instead of setting here:
@@ -49,7 +34,7 @@ services:
             # - USER_AGENT="..."                # set a custom USER_AGENT to avoid being blocked as a bot
             # ...
             # For more info, see: https://github.com/ArchiveBox/ArchiveBox/wiki/Docker#configuration
-        shm_size: "1gb"
+        shm_size: "1gb"                         # Chrome runs more efficiently when using a reasonably sized shared memory pool
             
         # For ad-blocking during archiving, uncomment this section and the pihole service below
         # networks:
@@ -78,18 +63,18 @@ services:
     # https://github.com/ArchiveBox/ArchiveBox/wiki/Chromium-Install#setting-up-a-chromium-user-profile
     # https://github.com/ArchiveBox/ArchiveBox/wiki/Chromium-Install#docker-vnc-setup
 
-    novnc:
-        image: theasp/novnc:latest
-        profiles:
-            - novnc
-        environment:
-            - DISPLAY_WIDTH=1920
-            - DISPLAY_HEIGHT=1080
-            - RUN_XTERM=no
-        ports:
-            # to view/control ArchiveBox's browser, visit: http://127.0.0.1:8080/vnc.html
-            # restricted to access from localhost by default because it has no authentication
-            - 127.0.0.1:8080:8080
+    # novnc:
+    #     image: theasp/novnc:latest
+    #     profiles:
+    #         - novnc
+    #     environment:
+    #         - DISPLAY_WIDTH=1920
+    #         - DISPLAY_HEIGHT=1080
+    #         - RUN_XTERM=no
+    #     ports:
+    #         # to view/control ArchiveBox's browser, visit: http://127.0.0.1:8080/vnc.html
+    #         # restricted to access from localhost by default because it has no authentication
+    #         - 127.0.0.1:8080:8080
 
 
     ### Example: Put Nginx in front of the ArchiveBox server for SSL termination and static file serving.
@@ -167,13 +152,13 @@ services:
     #         - ./data/wayback:/webarchive
 
 
-networks:
-    # network just used for pihole container to offer :53 dns resolving on fixed ip for archivebox container
-    dns:
-        ipam:
-            driver: default
-            config:
-                - subnet: 172.20.0.0/24
+# networks:
+#     # network just used for pihole container to offer :53 dns resolving on fixed ip for archivebox container
+#     dns:
+#         ipam:
+#             driver: default
+#             config:
+#                 - subnet: 172.20.0.0/24
 
 
 # HOW TO: Set up cloud storage for your ./data/archive (e.g. Amazon S3, Backblaze B2, Google Drive, OneDrive, SFTP, etc.)


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

<!--e.g. This PR fixes ABC or adds the ability to do XYZ...-->

# Related issues

<!-- e.g. #123 or Roadmap goal # https://github.com/pirate/ArchiveBox/wiki/Roadmap -->

# Changes these areas

- [ ] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the docker-compose setup for ArchiveBox. Defaults to `archivebox/archivebox:dev`, updates the init command, and disables optional services and env overrides to reduce setup friction.

- **Refactors**
  - Set default image to `archivebox/archivebox:dev`; unpins `platform` for native arch.
  - Update usage: remove `--install` from `init`.
  - Trim environment block (search backend and Chrome vars) to rely on defaults/config.
  - Comment out `novnc` service and the custom `dns` network examples.
  - Add a clarifying note on `shm_size` for Chrome.

<sup>Written for commit f7ccc525d1f23828e84433a957fbd1786267d221. Summary will update on new commits. <a href="https://cubic.dev/pr/ArchiveBox/ArchiveBox/pull/1802?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

