### PR TITLE
chore: improve ArchiveBox maintenance path

### DIFF
--- a/archivebox/tests/conftest.py
+++ b/archivebox/tests/conftest.py
@@ -98,6 +98,10 @@ def run_archivebox_cmd(
     base_env["SAVE_HTMLTOTEXT"] = "False"
 
     if env:
+        for key, value in env.items():
+            assert isinstance(value, str), (
+                f"env value for {key!r} must be a str, got {type(value).__name__}"
+            )
         base_env.update(env)
 
     _assert_safe_runtime_paths(cwd=data_dir, env=base_env)
@@ -230,6 +234,10 @@ def run_archivebox_cmd_cwd(
     base_env["SHOW_PROGRESS"] = "False"
 
     if env:
+        for key, value in env.items():
+            assert isinstance(value, str), (
+                f"env value for {key!r} must be a str, got {type(value).__name__}"
+            )
         base_env.update(env)
 
     _assert_safe_runtime_paths(cwd=cwd, env=base_env)

--- a/archivebox/tests/test_test_harness.py
+++ b/archivebox/tests/test_test_harness.py
@@ -28,3 +28,15 @@ def test_cli_helpers_reject_repo_root_runtime_paths():
 def test_runtime_guard_rejects_chdir_into_repo_root():
     with pytest.raises(AssertionError, match="repo root"):
         os.chdir(test_harness.REPO_ROOT)
+
+
+def test_cli_helpers_reject_non_string_env_values():
+    with pytest.raises(AssertionError, match="env value for 'SAVE_WGET' must be a str"):
+        test_harness.run_archivebox_cmd(
+            ["version"], data_dir=test_harness.SESSION_DATA_DIR, env={"SAVE_WGET": True}
+        )
+
+    with pytest.raises(AssertionError, match="env value for 'SAVE_WGET' must be a str"):
+        test_harness.run_archivebox_cmd_cwd(
+            ["version"], cwd=test_harness.SESSION_DATA_DIR, env={"SAVE_WGET": True}
+        )


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in archivebox/tests/conftest.py, archivebox/tests/fixtures.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add strict env var type checks to the CLI test helpers and extend tests for runtime path safety. This catches invalid configs early and makes the test harness more reliable.

- **Bug Fixes**
  - Assert all `env` values are strings in `run_archivebox_cmd` and `run_archivebox_cmd_cwd`.
  - Add tests that reject non-string env values and prevent `chdir` into the repo root.

<sup>Written for commit f8d9f0db8bd97df68715de70cd1ce3b1e0d76205. Summary will update on new commits. <a href="https://cubic.dev/pr/ArchiveBox/ArchiveBox/pull/1806?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

