### PR TITLE
Freeze resolved runtime config onto Crawl rows and centralize redaction

### DIFF
--- a/archivebox/config/common.py
+++ b/archivebox/config/common.py
@@ -67,6 +67,15 @@ def permissions_from_legacy_public_flags(raw_config: Mapping[str, object]) -> st
 _SENSITIVE_CONFIG_KEY_NEEDLES = ("TOKEN", "SECRET", "API_KEY", "APIKEY", "PASSWORD")
 SENSITIVE_CONFIG_VALUE_REDACTED = "********"
 _RUNTIME_CONFIG_KEYS = {"CRAWL_DIR", "SNAP_DIR"}
+_CRAWL_SCOPE_FROZEN = "frozen"
+_CRAWL_SCOPE_RUNTIME = "runtime"
+_CRAWL_SCOPE_INTERNAL = "internal"
+
+
+def _crawl_scope(extra: dict[str, Any] | None, default: str) -> str:
+    if isinstance(extra, dict):
+        return str(extra.get("crawl_scope") or default)
+    return default
 
 
 def _plugin_sensitive_config_keys() -> set[str]:
@@ -141,9 +150,10 @@ def build_crawl_config_snapshot(
     base_config: ArchiveBoxBaseConfig | Mapping[str, object] | None = None,
 ) -> dict[str, Any]:
     """Build the frozen runtime config stored on Crawl.config at creation time."""
-    effective = get_config(user=user, persona=persona, base_config=base_config)
-    frozen = normalize_runtime_config(effective, exclude_runtime_paths=True)
-    frozen.update(normalize_runtime_config(overrides or {}, exclude_runtime_paths=True))
+    effective = get_config(user=user, persona=persona, base_config=base_config, include_machine=False)
+    frozen = effective.for_crawl_frozen_config()
+    if overrides:
+        frozen = get_config(base_config=frozen, overrides=overrides, include_machine=False).for_crawl_frozen_config()
     return frozen
 
 def rprint(*args, file=None, **kwargs):
@@ -153,6 +163,7 @@ def rprint(*args, file=None, **kwargs):
 
 class ShellConfig(BaseConfigSet):
     toml_section_header: str = "SHELL_CONFIG"
+    crawl_config_scope: ClassVar[str] = _CRAWL_SCOPE_RUNTIME
 
     DEBUG: bool = Field(default="--debug" in sys.argv)
 
@@ -184,6 +195,7 @@ class ShellConfig(BaseConfigSet):
 
 class StorageConfig(BaseConfigSet):
     toml_section_header: str = "STORAGE_CONFIG"
+    crawl_config_scope: ClassVar[str] = _CRAWL_SCOPE_INTERNAL
 
     # ARCHIVE_DIR / USERS_DIR are resolved dynamically via get_config().
     ARCHIVE_DIR: Path = Field(default=CONSTANTS.ARCHIVE_DIR)
@@ -193,34 +205,36 @@ class StorageConfig(BaseConfigSet):
     # TMP_DIR must be a local, fast, readable/writable dir by archivebox user,
     # must be a short path due to unix path length restrictions for socket files (<100 chars)
     # must be a local SSD/tmpfs for speed and because bind mounts/network mounts/FUSE dont support unix sockets
-    TMP_DIR: Path = Field(default=CONSTANTS.DEFAULT_TMP_DIR)
+    TMP_DIR: Path = Field(default=CONSTANTS.DEFAULT_TMP_DIR, json_schema_extra={"crawl_scope": _CRAWL_SCOPE_RUNTIME})
 
     # LIB_DIR must be a local, fast, readable/writable dir by archivebox user,
     # must be able to contain executable binaries (up to 5GB size)
     # should not be a remote/network/FUSE mount for speed reasons, otherwise extractors will be slow
-    LIB_DIR: Path = Field(default=CONSTANTS.DEFAULT_LIB_DIR)
+    LIB_DIR: Path = Field(default=CONSTANTS.DEFAULT_LIB_DIR, json_schema_extra={"crawl_scope": _CRAWL_SCOPE_RUNTIME})
 
     # LIB_BIN_DIR is an optional human-facing symlink convenience directory.
     # Runtime lookup must use provider-specific paths under LIB_DIR instead.
-    LIB_BIN_DIR: Path = Field(default=CONSTANTS.DEFAULT_LIB_BIN_DIR)
+    LIB_BIN_DIR: Path = Field(default=CONSTANTS.DEFAULT_LIB_BIN_DIR, json_schema_extra={"crawl_scope": _CRAWL_SCOPE_RUNTIME})
 
     # CUSTOM_TEMPLATES_DIR allows users to override default templates
     # defaults to DATA_DIR / 'user_templates' but can be configured
     CUSTOM_TEMPLATES_DIR: Path = Field(default=CONSTANTS.CUSTOM_TEMPLATES_DIR)
 
-    OUTPUT_PERMISSIONS: str = Field(default="644")
+    OUTPUT_PERMISSIONS: str = Field(default="644", json_schema_extra={"crawl_scope": _CRAWL_SCOPE_RUNTIME})
     ENFORCE_ATOMIC_WRITES: bool = Field(default=True)
     ALLOW_NO_UNIX_SOCKETS: bool = Field(default=False, alias="ARCHIVEBOX_ALLOW_NO_UNIX_SOCKETS")
 
 
 class GeneralConfig(BaseConfigSet):
     toml_section_header: str = "GENERAL_CONFIG"
+    crawl_config_scope: ClassVar[str] = _CRAWL_SCOPE_INTERNAL
 
     TAG_SEPARATOR_PATTERN: str = Field(default=r"[,]")
 
 
 class ServerConfig(BaseConfigSet):
     toml_section_header: str = "SERVER_CONFIG"
+    crawl_config_scope: ClassVar[str] = _CRAWL_SCOPE_INTERNAL
 
     SERVER_SECURITY_MODES: ClassVar[tuple[str, ...]] = (
         "safe-subdomains-fullreplay",
@@ -301,6 +315,7 @@ class ServerConfig(BaseConfigSet):
 
 class DatabaseConfig(BaseConfigSet):
     toml_section_header: str = "DATABASE_CONFIG"
+    crawl_config_scope: ClassVar[str] = _CRAWL_SCOPE_INTERNAL
 
     DATABASE_NAME: str = Field(default=str(CONSTANTS.DATABASE_FILE), alias="ARCHIVEBOX_DATABASE_NAME")
     SQLITE_JOURNAL_MODE: str = Field(
@@ -320,6 +335,7 @@ class DatabaseConfig(BaseConfigSet):
 
 class ArchivingConfig(BaseConfigSet):
     toml_section_header: str = "ARCHIVING_CONFIG"
+    crawl_config_scope: ClassVar[str] = _CRAWL_SCOPE_FROZEN
 
     PLUGINS: str = Field(
         default="",
@@ -440,6 +456,7 @@ def parse_delete_after(value) -> timedelta | None:
 
 class SearchBackendConfig(BaseConfigSet):
     toml_section_header: str = "SEARCH_BACKEND_CONFIG"
+    crawl_config_scope: ClassVar[str] = _CRAWL_SCOPE_INTERNAL
 
     SEARCH_BACKEND_ENGINE: str = Field(default="ripgrep")
 
@@ -516,11 +533,86 @@ class ArchiveBoxBaseConfig(
         populate_by_name=True,
     )
 
-    DATA_DIR: Path = Field(default=CONSTANTS.DATA_DIR)
-    ABX_RUNTIME: str = Field(default="archivebox")
-    CRAWL_DIR: Path | None = Field(default=None)
-    SNAP_DIR: Path | None = Field(default=None)
+    DATA_DIR: Path = Field(default=CONSTANTS.DATA_DIR, json_schema_extra={"crawl_scope": _CRAWL_SCOPE_RUNTIME})
+    ABX_RUNTIME: str = Field(default="archivebox", json_schema_extra={"crawl_scope": _CRAWL_SCOPE_RUNTIME})
+    CRAWL_DIR: Path | None = Field(default=None, json_schema_extra={"crawl_scope": _CRAWL_SCOPE_RUNTIME})
+    SNAP_DIR: Path | None = Field(default=None, json_schema_extra={"crawl_scope": _CRAWL_SCOPE_RUNTIME})
     computed_config_keys: ClassVar[tuple[str, ...]] = COMPUTED_CONFIG_KEYS
+
+    @classmethod
+    def _core_config_classes(cls) -> tuple[type[BaseConfigSet], ...]:
+        return (
+            ShellConfig,
+            StorageConfig,
+            GeneralConfig,
+            ServerConfig,
+            DatabaseConfig,
+            ArchivingConfig,
+            SearchBackendConfig,
+            LDAPConfig,
+        )
+
+    @classmethod
+    def _core_field_crawl_scope(cls, key: str) -> str | None:
+        if key == "toml_section_header":
+            return _CRAWL_SCOPE_INTERNAL
+        for config_cls in cls._core_config_classes():
+            field = config_cls.model_fields.get(key)
+            if field is None:
+                continue
+            default_scope = getattr(config_cls, "crawl_config_scope", _CRAWL_SCOPE_INTERNAL)
+            return _crawl_scope(field.json_schema_extra, default_scope)
+        if key in ArchiveBoxBaseConfig.model_fields:
+            field = ArchiveBoxBaseConfig.model_fields[key]
+            return _crawl_scope(field.json_schema_extra, _CRAWL_SCOPE_INTERNAL)
+        return None
+
+    @classmethod
+    def _plugin_field_crawl_scope(cls, key: str) -> str | None:
+        for plugin_name, schema in PLUGIN_CONFIG_SCHEMAS.items():
+            properties = schema.get("properties") if isinstance(schema, dict) else None
+            if not isinstance(properties, dict) or key not in properties:
+                continue
+            prop_schema = properties.get(key) or {}
+            if isinstance(prop_schema, Mapping) and prop_schema.get("x-crawl-scope"):
+                return str(prop_schema["x-crawl-scope"])
+            if str(plugin_name).startswith("search_backend_"):
+                return _CRAWL_SCOPE_INTERNAL
+            upper = key.upper()
+            if (
+                upper == "PATH"
+                or upper.endswith("_PATH")
+                or upper.endswith("_DIR")
+                or upper.endswith("_BINARY")
+                or upper.endswith("_CACHE")
+                or upper.endswith("_COVERAGE")
+                or upper.endswith("_PYTHON")
+            ):
+                return _CRAWL_SCOPE_RUNTIME
+            return _CRAWL_SCOPE_FROZEN
+        return None
+
+    @classmethod
+    def crawl_config_scope_for_key(cls, key: str) -> str:
+        return cls._core_field_crawl_scope(key) or cls._plugin_field_crawl_scope(key) or _CRAWL_SCOPE_INTERNAL
+
+    def _crawl_scoped_config(self, *, include_runtime: bool) -> dict[str, Any]:
+        allowed_scopes = {_CRAWL_SCOPE_FROZEN}
+        if include_runtime:
+            allowed_scopes.add(_CRAWL_SCOPE_RUNTIME)
+        return {
+            key: value
+            for key, value in normalize_runtime_config(self).items()
+            if type(self).crawl_config_scope_for_key(key) in allowed_scopes
+        }
+
+    def for_crawl(self) -> dict[str, Any]:
+        """Config safe to pass to crawl/snapshot hook execution."""
+        return self._crawl_scoped_config(include_runtime=True)
+
+    def for_crawl_frozen_config(self) -> dict[str, Any]:
+        """Config safe to persist permanently on Crawl.config."""
+        return self._crawl_scoped_config(include_runtime=False)
 
     @model_validator(mode="after")
     def resolve_runtime_paths(self):
@@ -627,13 +719,15 @@ def get_config(
         persona = crawl.resolve_persona()
 
     config_data: ConfigPayload = dict(defaults or {})
+    base_config_payload: ConfigPayload = {}
     if crawl_config_base:
         config_data.update(dict(getattr(crawl, "config", None) or {}))
     elif base_config is not None:
         if isinstance(base_config, ArchiveBoxBaseConfig):
-            config_data.update(base_config.model_dump(mode="json"))
+            base_config_payload.update(base_config.model_dump(mode="json"))
         else:
-            config_data.update(dict(base_config))
+            base_config_payload.update(dict(base_config))
+        config_data.update(base_config_payload)
     else:
         config_data.update(ArchiveBoxConfig().model_dump(mode="json"))
         legacy_permissions = permissions_from_legacy_public_flags({**BaseConfigSet.load_from_file(CONSTANTS.CONFIG_FILE), **os.environ})
@@ -696,6 +790,8 @@ def get_config(
         )
         for plugin_config in plugin_sections.values():
             config_data.update(plugin_config)
+        if base_config_payload:
+            config_data.update({key: value for key, value in base_config_payload.items() if key in _archivebox_config_input_names()})
         if crawl_config_base:
             config_data.update(dict(getattr(crawl, "config", None) or {}))
         config_data.update(archivebox_scope_overrides)

--- a/archivebox/config/common.py
+++ b/archivebox/config/common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __package__ = "archivebox.config"
 
 import json
@@ -64,6 +66,15 @@ def permissions_from_legacy_public_flags(raw_config: Mapping[str, object]) -> st
 
 _SENSITIVE_CONFIG_KEY_NEEDLES = ("TOKEN", "SECRET", "API_KEY", "APIKEY", "PASSWORD")
 SENSITIVE_CONFIG_VALUE_REDACTED = "********"
+_RUNTIME_CONFIG_KEYS = {"CRAWL_DIR", "SNAP_DIR"}
+
+
+def _plugin_sensitive_config_keys() -> set[str]:
+    sensitive_keys: set[str] = set()
+    for prop_key, prop_schema in _plugin_config_properties(PLUGIN_CONFIG_SCHEMAS).items():
+        if isinstance(prop_schema, Mapping) and prop_schema.get("x-sensitive"):
+            sensitive_keys.add(str(prop_key))
+    return sensitive_keys
 
 
 def is_sensitive_config_key(key: str) -> bool:
@@ -77,8 +88,9 @@ def is_sensitive_config_key(key: str) -> bool:
     REST API responses, and any future surface that round-trips raw config
     values all agree on which keys to redact.
     """
-    upper = (key or "").upper()
-    return any(needle in upper for needle in _SENSITIVE_CONFIG_KEY_NEEDLES)
+    key = str(key or "")
+    upper = key.upper()
+    return key in _plugin_sensitive_config_keys() or any(needle in upper for needle in _SENSITIVE_CONFIG_KEY_NEEDLES)
 
 
 def redact_sensitive_config(config: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -102,6 +114,37 @@ def redact_sensitive_config(config: Mapping[str, Any] | None) -> dict[str, Any]:
             redacted[key] = value
     return redacted
 
+
+
+def normalize_runtime_config(config: BaseConfigSet | Mapping[str, Any] | str | None, *, exclude_runtime_paths: bool = False) -> dict[str, Any]:
+    """Return a JSON-safe config dict suitable for storage or event payloads."""
+    if config is None:
+        return {}
+    if isinstance(config, BaseConfigSet):
+        config = config.model_dump(mode="json")
+    elif isinstance(config, str):
+        config = json.loads(config)
+    else:
+        config = dict(config)
+    normalized = {key: value for key, value in json.loads(json.dumps(config, default=str)).items() if value is not None}
+    if exclude_runtime_paths:
+        for key in _RUNTIME_CONFIG_KEYS:
+            normalized.pop(key, None)
+    return normalized
+
+
+def build_crawl_config_snapshot(
+    *,
+    user: Any = None,
+    persona: Any = None,
+    overrides: Mapping[str, Any] | None = None,
+    base_config: ArchiveBoxBaseConfig | Mapping[str, object] | None = None,
+) -> dict[str, Any]:
+    """Build the frozen runtime config stored on Crawl.config at creation time."""
+    effective = get_config(user=user, persona=persona, base_config=base_config)
+    frozen = normalize_runtime_config(effective, exclude_runtime_paths=True)
+    frozen.update(normalize_runtime_config(overrides or {}, exclude_runtime_paths=True))
+    return frozen
 
 def rprint(*args, file=None, **kwargs):
     console = _STDERR_CONSOLE if file is sys.stderr else _STDOUT_CONSOLE
@@ -552,12 +595,12 @@ def get_config(
     1. Explicit overrides
     2. Per-ArchiveResult config
     3. Per-snapshot config and output path
-    4. Per-crawl config and output path
-    5. Per-user config
-    6. Per-persona derived config
-    7. Current machine derived config
-    8. Environment variables
-    9. Config file (ArchiveBox.conf)
+    4. Frozen per-crawl config and output path
+    5. Per-user config (only when resolving outside a crawl)
+    6. Per-persona derived config (only when resolving outside a crawl)
+    7. Current machine derived config (only when resolving outside a crawl)
+    8. Environment variables (only when resolving outside a crawl)
+    9. Config file (ArchiveBox.conf, only when resolving outside a crawl)
     10. Plugin schema defaults
     11. Core config defaults
     """
@@ -567,7 +610,9 @@ def get_config(
     if crawl is None and snapshot is not None:
         crawl = snapshot.crawl
 
-    if include_machine and machine is None:
+    crawl_config_base = crawl is not None and base_config is None
+
+    if include_machine and machine is None and not crawl_config_base:
         try:
             from django.apps import apps
 
@@ -578,11 +623,13 @@ def get_config(
         except Exception:
             machine = None
 
-    if persona is None and crawl is not None:
+    if persona is None and crawl is not None and not crawl_config_base:
         persona = crawl.resolve_persona()
 
     config_data: ConfigPayload = dict(defaults or {})
-    if base_config is not None:
+    if crawl_config_base:
+        config_data.update(dict(getattr(crawl, "config", None) or {}))
+    elif base_config is not None:
         if isinstance(base_config, ArchiveBoxBaseConfig):
             config_data.update(base_config.model_dump(mode="json"))
         else:
@@ -595,19 +642,20 @@ def get_config(
 
     scope_overrides: ConfigPayload = {}
 
-    if include_machine and machine is not None and machine.config:
-        from archivebox.machine.models import _sanitize_machine_config
+    if not crawl_config_base:
+        if include_machine and machine is not None and machine.config:
+            from archivebox.machine.models import _sanitize_machine_config
 
-        scope_overrides.update(_sanitize_machine_config(machine.config, lib_dir=config_data.get("LIB_DIR")))
+            scope_overrides.update(_sanitize_machine_config(machine.config, lib_dir=config_data.get("LIB_DIR")))
 
-    if persona is not None:
-        scope_overrides.update(persona.get_derived_config())
+        if persona is not None:
+            scope_overrides.update(persona.get_derived_config())
 
-    user_config = getattr(user, "config", None)
-    if user_config:
-        scope_overrides.update(user_config)
+        user_config = getattr(user, "config", None)
+        if user_config:
+            scope_overrides.update(user_config)
 
-    if crawl is not None and crawl.config:
+    if crawl is not None and crawl.config and not crawl_config_base:
         scope_overrides.update(crawl.config)
 
     if crawl is not None:
@@ -638,13 +686,18 @@ def get_config(
             plugin_name: schema.get("properties", {}) for plugin_name, schema in PLUGIN_CONFIG_SCHEMAS.items() if isinstance(schema, dict)
         }
         plugin_global_config = {key: str(value) if isinstance(value, Path) else value for key, value in config_data.items()}
+        plugin_user_config = _plugin_user_config(scope_overrides)
+        if not crawl_config_base:
+            plugin_user_config = {**BaseConfigSet.load_from_file(CONSTANTS.CONFIG_FILE), **plugin_user_config}
         plugin_sections = resolve_plugin_configs(
             plugin_schemas,
             global_config=plugin_global_config,
-            user_config={**BaseConfigSet.load_from_file(CONSTANTS.CONFIG_FILE), **_plugin_user_config(scope_overrides)},
+            user_config=plugin_user_config,
         )
         for plugin_config in plugin_sections.values():
             config_data.update(plugin_config)
+        if crawl_config_base:
+            config_data.update(dict(getattr(crawl, "config", None) or {}))
         config_data.update(archivebox_scope_overrides)
 
     config_data["ABX_RUNTIME"] = "archivebox"

--- a/archivebox/config/common.py
+++ b/archivebox/config/common.py
@@ -15,7 +15,7 @@ from typing import Any, ClassVar, cast
 from pathlib import Path
 
 from rich.console import Console
-from pydantic import BaseModel, Field, create_model, field_validator, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, create_model, field_validator, model_validator
 from pydantic_settings import SettingsConfigDict
 from abx_plugins.plugins.base.utils import BASE_CONFIG_PATH, build_config_model, resolve_plugin_configs
 
@@ -66,16 +66,21 @@ def permissions_from_legacy_public_flags(raw_config: Mapping[str, object]) -> st
 
 _SENSITIVE_CONFIG_KEY_NEEDLES = ("TOKEN", "SECRET", "API_KEY", "APIKEY", "PASSWORD")
 SENSITIVE_CONFIG_VALUE_REDACTED = "********"
-_RUNTIME_CONFIG_KEYS = {"CRAWL_DIR", "SNAP_DIR"}
-_CRAWL_SCOPE_FROZEN = "frozen"
-_CRAWL_SCOPE_RUNTIME = "runtime"
-_CRAWL_SCOPE_INTERNAL = "internal"
+_SCOPE_CRAWL = "crawl"
+_SCOPE_RUNTIME = "runtime"
+_SCOPE_SYSTEM = "system"
 
 
-def _crawl_scope(extra: dict[str, Any] | None, default: str) -> str:
+def _scope(extra: dict[str, Any] | None, default: str) -> str:
     if isinstance(extra, dict):
-        return str(extra.get("crawl_scope") or default)
+        return str(extra.get("scope") or default)
     return default
+
+
+def _config_class_scope(config_cls: type[BaseConfigSet]) -> str:
+    private_attrs = getattr(config_cls, "__private_attributes__", {}) or {}
+    private_attr = private_attrs.get("_scope")
+    return str(getattr(private_attr, "default", None) or _SCOPE_SYSTEM)
 
 
 def _plugin_sensitive_config_keys() -> set[str]:
@@ -125,7 +130,7 @@ def redact_sensitive_config(config: Mapping[str, Any] | None) -> dict[str, Any]:
 
 
 
-def normalize_runtime_config(config: BaseConfigSet | Mapping[str, Any] | str | None, *, exclude_runtime_paths: bool = False) -> dict[str, Any]:
+def normalize_runtime_config(config: BaseConfigSet | Mapping[str, Any] | str | None) -> dict[str, Any]:
     """Return a JSON-safe config dict suitable for storage or event payloads."""
     if config is None:
         return {}
@@ -135,11 +140,7 @@ def normalize_runtime_config(config: BaseConfigSet | Mapping[str, Any] | str | N
         config = json.loads(config)
     else:
         config = dict(config)
-    normalized = {key: value for key, value in json.loads(json.dumps(config, default=str)).items() if value is not None}
-    if exclude_runtime_paths:
-        for key in _RUNTIME_CONFIG_KEYS:
-            normalized.pop(key, None)
-    return normalized
+    return {key: value for key, value in json.loads(json.dumps(config, default=str)).items() if value is not None}
 
 
 def build_crawl_config_snapshot(
@@ -163,7 +164,7 @@ def rprint(*args, file=None, **kwargs):
 
 class ShellConfig(BaseConfigSet):
     toml_section_header: str = "SHELL_CONFIG"
-    crawl_config_scope: ClassVar[str] = _CRAWL_SCOPE_RUNTIME
+    _scope: str = PrivateAttr(default=_SCOPE_RUNTIME)
 
     DEBUG: bool = Field(default="--debug" in sys.argv)
 
@@ -195,7 +196,7 @@ class ShellConfig(BaseConfigSet):
 
 class StorageConfig(BaseConfigSet):
     toml_section_header: str = "STORAGE_CONFIG"
-    crawl_config_scope: ClassVar[str] = _CRAWL_SCOPE_INTERNAL
+    _scope: str = PrivateAttr(default=_SCOPE_SYSTEM)
 
     # ARCHIVE_DIR / USERS_DIR are resolved dynamically via get_config().
     ARCHIVE_DIR: Path = Field(default=CONSTANTS.ARCHIVE_DIR)
@@ -205,36 +206,36 @@ class StorageConfig(BaseConfigSet):
     # TMP_DIR must be a local, fast, readable/writable dir by archivebox user,
     # must be a short path due to unix path length restrictions for socket files (<100 chars)
     # must be a local SSD/tmpfs for speed and because bind mounts/network mounts/FUSE dont support unix sockets
-    TMP_DIR: Path = Field(default=CONSTANTS.DEFAULT_TMP_DIR, json_schema_extra={"crawl_scope": _CRAWL_SCOPE_RUNTIME})
+    TMP_DIR: Path = Field(default=CONSTANTS.DEFAULT_TMP_DIR, json_schema_extra={"scope": _SCOPE_RUNTIME})
 
     # LIB_DIR must be a local, fast, readable/writable dir by archivebox user,
     # must be able to contain executable binaries (up to 5GB size)
     # should not be a remote/network/FUSE mount for speed reasons, otherwise extractors will be slow
-    LIB_DIR: Path = Field(default=CONSTANTS.DEFAULT_LIB_DIR, json_schema_extra={"crawl_scope": _CRAWL_SCOPE_RUNTIME})
+    LIB_DIR: Path = Field(default=CONSTANTS.DEFAULT_LIB_DIR, json_schema_extra={"scope": _SCOPE_RUNTIME})
 
     # LIB_BIN_DIR is an optional human-facing symlink convenience directory.
     # Runtime lookup must use provider-specific paths under LIB_DIR instead.
-    LIB_BIN_DIR: Path = Field(default=CONSTANTS.DEFAULT_LIB_BIN_DIR, json_schema_extra={"crawl_scope": _CRAWL_SCOPE_RUNTIME})
+    LIB_BIN_DIR: Path = Field(default=CONSTANTS.DEFAULT_LIB_BIN_DIR, json_schema_extra={"scope": _SCOPE_RUNTIME})
 
     # CUSTOM_TEMPLATES_DIR allows users to override default templates
     # defaults to DATA_DIR / 'user_templates' but can be configured
     CUSTOM_TEMPLATES_DIR: Path = Field(default=CONSTANTS.CUSTOM_TEMPLATES_DIR)
 
-    OUTPUT_PERMISSIONS: str = Field(default="644", json_schema_extra={"crawl_scope": _CRAWL_SCOPE_RUNTIME})
+    OUTPUT_PERMISSIONS: str = Field(default="644", json_schema_extra={"scope": _SCOPE_RUNTIME})
     ENFORCE_ATOMIC_WRITES: bool = Field(default=True)
     ALLOW_NO_UNIX_SOCKETS: bool = Field(default=False, alias="ARCHIVEBOX_ALLOW_NO_UNIX_SOCKETS")
 
 
 class GeneralConfig(BaseConfigSet):
     toml_section_header: str = "GENERAL_CONFIG"
-    crawl_config_scope: ClassVar[str] = _CRAWL_SCOPE_INTERNAL
+    _scope: str = PrivateAttr(default=_SCOPE_SYSTEM)
 
     TAG_SEPARATOR_PATTERN: str = Field(default=r"[,]")
 
 
 class ServerConfig(BaseConfigSet):
     toml_section_header: str = "SERVER_CONFIG"
-    crawl_config_scope: ClassVar[str] = _CRAWL_SCOPE_INTERNAL
+    _scope: str = PrivateAttr(default=_SCOPE_SYSTEM)
 
     SERVER_SECURITY_MODES: ClassVar[tuple[str, ...]] = (
         "safe-subdomains-fullreplay",
@@ -315,7 +316,7 @@ class ServerConfig(BaseConfigSet):
 
 class DatabaseConfig(BaseConfigSet):
     toml_section_header: str = "DATABASE_CONFIG"
-    crawl_config_scope: ClassVar[str] = _CRAWL_SCOPE_INTERNAL
+    _scope: str = PrivateAttr(default=_SCOPE_SYSTEM)
 
     DATABASE_NAME: str = Field(default=str(CONSTANTS.DATABASE_FILE), alias="ARCHIVEBOX_DATABASE_NAME")
     SQLITE_JOURNAL_MODE: str = Field(
@@ -335,7 +336,7 @@ class DatabaseConfig(BaseConfigSet):
 
 class ArchivingConfig(BaseConfigSet):
     toml_section_header: str = "ARCHIVING_CONFIG"
-    crawl_config_scope: ClassVar[str] = _CRAWL_SCOPE_FROZEN
+    _scope: str = PrivateAttr(default=_SCOPE_CRAWL)
 
     PLUGINS: str = Field(
         default="",
@@ -456,7 +457,7 @@ def parse_delete_after(value) -> timedelta | None:
 
 class SearchBackendConfig(BaseConfigSet):
     toml_section_header: str = "SEARCH_BACKEND_CONFIG"
-    crawl_config_scope: ClassVar[str] = _CRAWL_SCOPE_INTERNAL
+    _scope: str = PrivateAttr(default=_SCOPE_SYSTEM)
 
     SEARCH_BACKEND_ENGINE: str = Field(default="ripgrep")
 
@@ -533,10 +534,10 @@ class ArchiveBoxBaseConfig(
         populate_by_name=True,
     )
 
-    DATA_DIR: Path = Field(default=CONSTANTS.DATA_DIR, json_schema_extra={"crawl_scope": _CRAWL_SCOPE_RUNTIME})
-    ABX_RUNTIME: str = Field(default="archivebox", json_schema_extra={"crawl_scope": _CRAWL_SCOPE_RUNTIME})
-    CRAWL_DIR: Path | None = Field(default=None, json_schema_extra={"crawl_scope": _CRAWL_SCOPE_RUNTIME})
-    SNAP_DIR: Path | None = Field(default=None, json_schema_extra={"crawl_scope": _CRAWL_SCOPE_RUNTIME})
+    DATA_DIR: Path = Field(default=CONSTANTS.DATA_DIR, json_schema_extra={"scope": _SCOPE_RUNTIME})
+    ABX_RUNTIME: str = Field(default="archivebox", json_schema_extra={"scope": _SCOPE_RUNTIME})
+    CRAWL_DIR: Path | None = Field(default=None, json_schema_extra={"scope": _SCOPE_RUNTIME})
+    SNAP_DIR: Path | None = Field(default=None, json_schema_extra={"scope": _SCOPE_RUNTIME})
     computed_config_keys: ClassVar[tuple[str, ...]] = COMPUTED_CONFIG_KEYS
 
     @classmethod
@@ -553,31 +554,31 @@ class ArchiveBoxBaseConfig(
         )
 
     @classmethod
-    def _core_field_crawl_scope(cls, key: str) -> str | None:
+    def _core_field_scope(cls, key: str) -> str | None:
         if key == "toml_section_header":
-            return _CRAWL_SCOPE_INTERNAL
+            return _SCOPE_SYSTEM
         for config_cls in cls._core_config_classes():
             field = config_cls.model_fields.get(key)
             if field is None:
                 continue
-            default_scope = getattr(config_cls, "crawl_config_scope", _CRAWL_SCOPE_INTERNAL)
-            return _crawl_scope(field.json_schema_extra, default_scope)
+            default_scope = _config_class_scope(config_cls)
+            return _scope(field.json_schema_extra, default_scope)
         if key in ArchiveBoxBaseConfig.model_fields:
             field = ArchiveBoxBaseConfig.model_fields[key]
-            return _crawl_scope(field.json_schema_extra, _CRAWL_SCOPE_INTERNAL)
+            return _scope(field.json_schema_extra, _SCOPE_SYSTEM)
         return None
 
     @classmethod
-    def _plugin_field_crawl_scope(cls, key: str) -> str | None:
+    def _plugin_field_scope(cls, key: str) -> str | None:
         for plugin_name, schema in PLUGIN_CONFIG_SCHEMAS.items():
             properties = schema.get("properties") if isinstance(schema, dict) else None
             if not isinstance(properties, dict) or key not in properties:
                 continue
             prop_schema = properties.get(key) or {}
-            if isinstance(prop_schema, Mapping) and prop_schema.get("x-crawl-scope"):
-                return str(prop_schema["x-crawl-scope"])
+            if isinstance(prop_schema, Mapping) and prop_schema.get("x-scope"):
+                return str(prop_schema["x-scope"])
             if str(plugin_name).startswith("search_backend_"):
-                return _CRAWL_SCOPE_INTERNAL
+                return _SCOPE_SYSTEM
             upper = key.upper()
             if (
                 upper == "PATH"
@@ -588,31 +589,31 @@ class ArchiveBoxBaseConfig(
                 or upper.endswith("_COVERAGE")
                 or upper.endswith("_PYTHON")
             ):
-                return _CRAWL_SCOPE_RUNTIME
-            return _CRAWL_SCOPE_FROZEN
+                return _SCOPE_RUNTIME
+            return _SCOPE_CRAWL
         return None
 
     @classmethod
-    def crawl_config_scope_for_key(cls, key: str) -> str:
-        return cls._core_field_crawl_scope(key) or cls._plugin_field_crawl_scope(key) or _CRAWL_SCOPE_INTERNAL
+    def scope_for_key(cls, key: str) -> str:
+        return cls._core_field_scope(key) or cls._plugin_field_scope(key) or _SCOPE_SYSTEM
 
-    def _crawl_scoped_config(self, *, include_runtime: bool) -> dict[str, Any]:
-        allowed_scopes = {_CRAWL_SCOPE_FROZEN}
+    def _scoped_config(self, *, include_runtime: bool) -> dict[str, Any]:
+        allowed_scopes = {_SCOPE_CRAWL}
         if include_runtime:
-            allowed_scopes.add(_CRAWL_SCOPE_RUNTIME)
+            allowed_scopes.add(_SCOPE_RUNTIME)
         return {
             key: value
             for key, value in normalize_runtime_config(self).items()
-            if type(self).crawl_config_scope_for_key(key) in allowed_scopes
+            if type(self).scope_for_key(key) in allowed_scopes
         }
 
     def for_crawl(self) -> dict[str, Any]:
         """Config safe to pass to crawl/snapshot hook execution."""
-        return self._crawl_scoped_config(include_runtime=True)
+        return self._scoped_config(include_runtime=True)
 
     def for_crawl_frozen_config(self) -> dict[str, Any]:
         """Config safe to persist permanently on Crawl.config."""
-        return self._crawl_scoped_config(include_runtime=False)
+        return self._scoped_config(include_runtime=False)
 
     @model_validator(mode="after")
     def resolve_runtime_paths(self):

--- a/archivebox/config/ldap.py
+++ b/archivebox/config/ldap.py
@@ -1,5 +1,7 @@
 __package__ = "archivebox.config"
 
+from typing import ClassVar
+
 from pydantic import Field
 
 from archivebox.config.configset import BaseConfigSet
@@ -14,6 +16,7 @@ class LDAPConfig(BaseConfigSet):
     """
 
     toml_section_header: str = "LDAP_CONFIG"
+    crawl_config_scope: ClassVar[str] = "internal"
 
     LDAP_ENABLED: bool = Field(default=False)
     LDAP_SERVER_URI: str | None = Field(default=None)

--- a/archivebox/config/ldap.py
+++ b/archivebox/config/ldap.py
@@ -1,8 +1,6 @@
 __package__ = "archivebox.config"
 
-from typing import ClassVar
-
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 
 from archivebox.config.configset import BaseConfigSet
 
@@ -16,7 +14,7 @@ class LDAPConfig(BaseConfigSet):
     """
 
     toml_section_header: str = "LDAP_CONFIG"
-    crawl_config_scope: ClassVar[str] = "internal"
+    _scope: str = PrivateAttr(default="system")
 
     LDAP_ENABLED: bool = Field(default=False)
     LDAP_SERVER_URI: str | None = Field(default=None)

--- a/archivebox/core/forms.py
+++ b/archivebox/core/forms.py
@@ -453,9 +453,9 @@ class PluginConfigFormMixin:
                 if "array" in _schema_types(prop_schema) and isinstance(prop_schema.get("enum"), list):
                     raw_value = self.data.getlist(input_name)
 
-                from archivebox.config.common import is_sensitive_config_key
+                from archivebox.config.common import SENSITIVE_CONFIG_VALUE_REDACTED, is_sensitive_config_key
 
-                if (prop_schema.get("x-sensitive") or is_sensitive_config_key(config_key)) and raw_value == "":
+                if (prop_schema.get("x-sensitive") or is_sensitive_config_key(config_key)) and raw_value in ("", SENSITIVE_CONFIG_VALUE_REDACTED):
                     continue
 
                 try:

--- a/archivebox/core/models.py
+++ b/archivebox/core/models.py
@@ -636,12 +636,7 @@ class Snapshot(ModelWithDeleteAfter, ModelWithOutputDir, ModelWithConfig, ModelW
 
     @classmethod
     def missing_delete_at_candidates(cls):
-        from archivebox.personas.models import Persona
-
-        persona_ids = Persona.objects.filter(config__has_key="DELETE_AFTER").values_list("id", flat=True)
-        return cls.objects.filter(delete_at__isnull=True).filter(
-            Q(config__has_key="DELETE_AFTER") | Q(crawl__config__has_key="DELETE_AFTER") | Q(crawl__persona_id__in=persona_ids),
-        )
+        return cls.objects.filter(delete_at__isnull=True).filter(Q(config__has_key="DELETE_AFTER") | Q(crawl__config__has_key="DELETE_AFTER"))
 
     @classmethod
     def is_archivebox_internal_url(cls, url: str) -> bool:
@@ -3498,14 +3493,10 @@ class ArchiveResult(ModelWithDeleteAfter, ModelWithOutputDir, ModelWithConfig, M
 
     @classmethod
     def missing_delete_at_candidates(cls):
-        from archivebox.personas.models import Persona
-
-        persona_ids = Persona.objects.filter(config__has_key="DELETE_AFTER").values_list("id", flat=True)
         return cls.objects.filter(delete_at__isnull=True).filter(
             Q(config__has_key="DELETE_AFTER")
             | Q(snapshot__config__has_key="DELETE_AFTER")
-            | Q(snapshot__crawl__config__has_key="DELETE_AFTER")
-            | Q(snapshot__crawl__persona_id__in=persona_ids),
+            | Q(snapshot__crawl__config__has_key="DELETE_AFTER"),
         )
 
     @property

--- a/archivebox/core/views.py
+++ b/archivebox/core/views.py
@@ -2509,10 +2509,9 @@ def find_config_type(key: str) -> str:
 
 
 def key_is_safe(key: str) -> bool:
-    for term in ("key", "password", "secret", "token"):
-        if term in key.lower():
-            return False
-    return True
+    from archivebox.config.common import is_sensitive_config_key
+
+    return not is_sensitive_config_key(key)
 
 
 def find_config_source(key: str, merged_config: dict) -> str:

--- a/archivebox/crawls/migrations/0018_freeze_crawl_config_snapshots.py
+++ b/archivebox/crawls/migrations/0018_freeze_crawl_config_snapshots.py
@@ -1,0 +1,33 @@
+from django.db import migrations
+
+
+def freeze_existing_crawl_configs(apps, schema_editor):
+    from archivebox.config.common import build_crawl_config_snapshot
+    from archivebox.personas.models import Persona
+    from django.contrib.auth import get_user_model
+
+    Crawl = apps.get_model("crawls", "Crawl")
+    User = get_user_model()
+    db_alias = schema_editor.connection.alias
+
+    for crawl in Crawl.objects.using(db_alias).select_related("persona", "created_by").iterator(chunk_size=200):
+        current_config = dict(crawl.config or {})
+        persona = Persona.objects.using(db_alias).filter(pk=getattr(crawl, "persona_id", None)).first()
+        user = User.objects.using(db_alias).filter(pk=getattr(crawl, "created_by_id", None)).first()
+        frozen_config = build_crawl_config_snapshot(
+            user=user,
+            persona=persona,
+            overrides=current_config,
+        )
+        if frozen_config != current_config:
+            Crawl.objects.using(db_alias).filter(pk=crawl.pk).update(config=frozen_config)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("crawls", "0017_drop_stale_crawl_limit_columns"),
+    ]
+
+    operations = [
+        migrations.RunPython(freeze_existing_crawl_configs, migrations.RunPython.noop),
+    ]

--- a/archivebox/crawls/models.py
+++ b/archivebox/crawls/models.py
@@ -102,13 +102,39 @@ class CrawlSchedule(ModelWithUUID, ModelWithNotes):
         return self.is_enabled and self.next_run_at <= now
 
     def enqueue(self, queued_at=None) -> "Crawl":
+        from archivebox.config.common import build_crawl_config_snapshot
+
         queued_at = queued_at or timezone.now()
         template = self.template
         label = template.label or self.label
+        persona = template.persona if template.persona_id else None
+        user = template.created_by if template.created_by_id else None
+
+        schedule_overrides = {
+            key: value
+            for key, value in dict(template.config or {}).items()
+            if key
+            in {
+                "PERMISSIONS",
+                "PLUGINS",
+                "INDEX_ONLY",
+                "ONLY_NEW",
+                "TIMEOUT",
+                "CRAWL_MAX_URLS",
+                "CRAWL_MAX_SIZE",
+                "CRAWL_TIMEOUT",
+                "CRAWL_MAX_CONCURRENT_SNAPSHOTS",
+                "SNAPSHOT_MAX_SIZE",
+                "PARSER",
+                "URL_ALLOWLIST",
+                "URL_DENYLIST",
+                "DELETE_AFTER",
+            }
+        }
 
         return Crawl.objects.create(
             urls=template.urls,
-            config=template.config or {},
+            config=build_crawl_config_snapshot(user=user, persona=persona, overrides=schedule_overrides),
             max_depth=template.max_depth,
             tags_str=template.tags_str,
             persona_id=template.persona_id,
@@ -273,10 +299,7 @@ class Crawl(ModelWithDeleteAfter, ModelWithOutputDir, ModelWithConfig, ModelWith
 
     @classmethod
     def missing_delete_at_candidates(cls):
-        from archivebox.personas.models import Persona
-
-        persona_ids = Persona.objects.filter(config__has_key="DELETE_AFTER").values_list("id", flat=True)
-        return cls.objects.filter(delete_at__isnull=True).filter(Q(config__has_key="DELETE_AFTER") | Q(persona_id__in=persona_ids))
+        return cls.objects.filter(delete_at__isnull=True, config__has_key="DELETE_AFTER")
 
     def save(self, *args, **kwargs):
         update_fields = kwargs.get("update_fields")
@@ -287,11 +310,16 @@ class Crawl(ModelWithDeleteAfter, ModelWithOutputDir, ModelWithConfig, ModelWith
             previous_tag_names = set(self.parse_tag_names(old_crawl.tags_str or ""))
 
         config = dict(self.config or {})
+        is_new = self._state.adding or old_crawl is None
+        persona = self.persona if self.persona_id else None
+        user = self.created_by if self.created_by_id else None
+        if is_new:
+            from archivebox.config.common import build_crawl_config_snapshot
+
+            config = build_crawl_config_snapshot(user=user, persona=persona, overrides=config)
         if str(config.get("PERMISSIONS") or "").strip().lower() not in PERMISSIONS_VALUES:
             from archivebox.config.common import get_config
 
-            persona = self.persona if self.persona_id else None
-            user = self.created_by if self.created_by_id else None
             config["PERMISSIONS"] = normalize_permissions(get_config(persona=persona, user=user, include_machine=True).PERMISSIONS)
         if "CRAWL_MAX_CONCURRENT_SNAPSHOTS" in config:
             raw_concurrency = config["CRAWL_MAX_CONCURRENT_SNAPSHOTS"]

--- a/archivebox/crawls/models.py
+++ b/archivebox/crawls/models.py
@@ -110,31 +110,17 @@ class CrawlSchedule(ModelWithUUID, ModelWithNotes):
         persona = template.persona if template.persona_id else None
         user = template.created_by if template.created_by_id else None
 
-        schedule_overrides = {
-            key: value
-            for key, value in dict(template.config or {}).items()
-            if key
-            in {
-                "PERMISSIONS",
-                "PLUGINS",
-                "INDEX_ONLY",
-                "ONLY_NEW",
-                "TIMEOUT",
-                "CRAWL_MAX_URLS",
-                "CRAWL_MAX_SIZE",
-                "CRAWL_TIMEOUT",
-                "CRAWL_MAX_CONCURRENT_SNAPSHOTS",
-                "SNAPSHOT_MAX_SIZE",
-                "PARSER",
-                "URL_ALLOWLIST",
-                "URL_DENYLIST",
-                "DELETE_AFTER",
-            }
-        }
+        template_config = dict(template.config or {})
+        inherited_keys = set()
+        if persona is not None:
+            inherited_keys.update(persona.get_derived_config())
+        if user is not None and getattr(user, "config", None):
+            inherited_keys.update(user.config)
+        template_overrides = {key: value for key, value in template_config.items() if key not in inherited_keys}
 
         return Crawl.objects.create(
             urls=template.urls,
-            config=build_crawl_config_snapshot(user=user, persona=persona, overrides=schedule_overrides),
+            config=build_crawl_config_snapshot(user=user, persona=persona, overrides=template_overrides),
             max_depth=template.max_depth,
             tags_str=template.tags_str,
             persona_id=template.persona_id,

--- a/archivebox/hooks.py
+++ b/archivebox/hooks.py
@@ -324,6 +324,7 @@ def run_hook(
 
     config_scope = {key.removeprefix("config_"): kwargs.pop(key) for key in list(kwargs) if key.startswith("config_")}
     resolved_config = get_config(overrides=_config_to_overrides(config), **config_scope)
+    hook_config = resolved_config.for_crawl() if hasattr(resolved_config, "for_crawl") else _config_to_overrides(resolved_config)
 
     # Auto-detect timeout from plugin config if not explicitly provided
     if timeout is None:
@@ -463,7 +464,7 @@ def run_hook(
         "SNAP_DIR",
         "CRAWL_DIR",
     }
-    for key, value in resolved_config.items():
+    for key, value in hook_config.items():
         if key in SKIP_KEYS:
             continue  # Already handled specially above, don't overwrite
         if value is None:

--- a/archivebox/services/runner.py
+++ b/archivebox/services/runner.py
@@ -125,6 +125,8 @@ def _count_selected_hooks(plugins: dict[str, Plugin], selected_plugins: list[str
 def _normalize_runtime_config(config: BaseConfigSet | Mapping[str, Any] | str | None) -> dict[str, Any]:
     from archivebox.config.common import normalize_runtime_config
 
+    if isinstance(config, BaseConfigSet) and hasattr(config, "for_crawl"):
+        return config.for_crawl()
     return normalize_runtime_config(config)
 
 

--- a/archivebox/services/runner.py
+++ b/archivebox/services/runner.py
@@ -123,15 +123,9 @@ def _count_selected_hooks(plugins: dict[str, Plugin], selected_plugins: list[str
 
 
 def _normalize_runtime_config(config: BaseConfigSet | Mapping[str, Any] | str | None) -> dict[str, Any]:
-    if config is None:
-        return {}
-    if isinstance(config, BaseConfigSet):
-        config = config.model_dump(mode="json")
-    elif isinstance(config, str):
-        config = json.loads(config)
-    else:
-        config = dict(config)
-    return {key: value for key, value in json.loads(json.dumps(config, default=str)).items() if value is not None}
+    from archivebox.config.common import normalize_runtime_config
+
+    return normalize_runtime_config(config)
 
 
 def _runner_task_context() -> contextvars.Context:

--- a/archivebox/tests/test_cli_add.py
+++ b/archivebox/tests/test_cli_add.py
@@ -269,7 +269,7 @@ def test_add_records_selected_persona_on_crawl(tmp_path, process, disable_extrac
         crawl = Crawl.objects.get()
 
     assert crawl.persona_id
-    assert crawl.config.get("DEFAULT_PERSONA") is None
+    assert crawl.config["ACTIVE_PERSONA"] == "Default"
     assert (tmp_path / "personas" / "Default" / "chrome_profile").is_dir()
 
 

--- a/archivebox/tests/test_frozen_crawl_config.py
+++ b/archivebox/tests/test_frozen_crawl_config.py
@@ -9,6 +9,14 @@ SENSITIVE_SECRET = "raw-twocaptcha-secret-for-frozen-crawl-test"
 UPDATED_SECRET = "updated-secret-that-must-not-affect-old-crawl"
 
 
+@pytest.fixture
+def archivebox_db(initialized_archive):
+    from archivebox.tests.test_orm_helpers import use_archivebox_db
+
+    with use_archivebox_db(initialized_archive):
+        yield initialized_archive
+
+
 def _user(username="frozen-config-admin"):
     from django.contrib.auth import get_user_model
 
@@ -36,7 +44,7 @@ def _persona(user, *, name="Frozen Persona", secret=SENSITIVE_SECRET, user_agent
     return persona
 
 
-def test_crawl_save_freezes_full_raw_persona_config_and_redacts_public_serialization():
+def test_crawl_save_freezes_full_raw_persona_config_and_redacts_public_serialization(archivebox_db):
     from archivebox.config.common import SENSITIVE_CONFIG_VALUE_REDACTED, get_config
     from archivebox.crawls.models import Crawl
 
@@ -83,7 +91,7 @@ def test_crawl_save_freezes_full_raw_persona_config_and_redacts_public_serializa
     assert SENSITIVE_SECRET not in str(public_json)
 
 
-def test_snapshot_config_overlays_frozen_crawl_without_re_reading_persona():
+def test_snapshot_config_overlays_frozen_crawl_without_re_reading_persona(archivebox_db):
     from archivebox.config.common import get_config
     from archivebox.core.models import Snapshot
     from archivebox.crawls.models import Crawl
@@ -107,7 +115,17 @@ def test_snapshot_config_overlays_frozen_crawl_without_re_reading_persona():
     assert snapshot.config == {"TIMEOUT": 22, "ANTHROPIC_API_KEY": "snapshot-secret"}
 
 
-def test_api_create_and_cli_add_store_full_frozen_config():
+def test_config_scopes_are_derived_from_section_and_field_metadata():
+    from archivebox.config.common import ArchiveBoxConfig
+
+    assert ArchiveBoxConfig.scope_for_key("TIMEOUT") == "crawl"
+    assert ArchiveBoxConfig.scope_for_key("DEBUG") == "runtime"
+    assert ArchiveBoxConfig.scope_for_key("CRAWL_DIR") == "runtime"
+    assert ArchiveBoxConfig.scope_for_key("SECRET_KEY") == "system"
+    assert ArchiveBoxConfig.scope_for_key("DATABASE_NAME") == "system"
+
+
+def test_api_create_and_cli_add_store_full_frozen_config(archivebox_db):
     from archivebox.api.v1_crawls import CrawlCreateSchema, CrawlSchema, create_crawl
     from archivebox.cli.archivebox_add import add
     from archivebox.config.common import SENSITIVE_CONFIG_VALUE_REDACTED
@@ -146,7 +164,7 @@ def test_api_create_and_cli_add_store_full_frozen_config():
     assert cli_crawl.config["TWOCAPTCHA_API_KEY"] == SENSITIVE_SECRET
 
 
-def test_schedule_enqueue_refreezes_using_current_template_persona_defaults():
+def test_schedule_enqueue_refreezes_using_current_template_persona_defaults(archivebox_db):
     from archivebox.crawls.models import Crawl, CrawlSchedule
 
     user = _user("frozen-config-schedule-admin")
@@ -155,7 +173,7 @@ def test_schedule_enqueue_refreezes_using_current_template_persona_defaults():
         urls="https://example.com/scheduled",
         persona=persona,
         created_by=user,
-        config={"TIMEOUT": 55},
+        config={"TIMEOUT": 55, "SECRET_KEY": "template-secret-must-not-freeze", "PUBLIC_ADD_VIEW": True},
         status=Crawl.StatusChoices.PAUSED,
     )
     schedule = CrawlSchedule.objects.create(template=template, schedule="daily", created_by=user)
@@ -168,5 +186,7 @@ def test_schedule_enqueue_refreezes_using_current_template_persona_defaults():
     assert child.config["TIMEOUT"] == 55
     assert child.config["USER_AGENT"] == "Current schedule UA"
     assert child.config["TWOCAPTCHA_API_KEY"] == UPDATED_SECRET
+    assert "SECRET_KEY" not in child.config
+    assert "PUBLIC_ADD_VIEW" not in child.config
     assert template.config["USER_AGENT"] == "Initial schedule UA"
     assert template.config["TWOCAPTCHA_API_KEY"] == SENSITIVE_SECRET

--- a/archivebox/tests/test_frozen_crawl_config.py
+++ b/archivebox/tests/test_frozen_crawl_config.py
@@ -59,6 +59,10 @@ def test_crawl_save_freezes_full_raw_persona_config_and_redacts_public_serializa
     assert crawl.config["CRAWL_MAX_CONCURRENT_SNAPSHOTS"] == 3
     assert "CRAWL_DIR" not in crawl.config
     assert "SNAP_DIR" not in crawl.config
+    assert "DEBUG" not in crawl.config
+    assert "SECRET_KEY" not in crawl.config
+    assert "PUBLIC_ADD_VIEW" not in crawl.config
+    assert "DATABASE_NAME" not in crawl.config
 
     persona.config["USER_AGENT"] = "Mutated UA"
     persona.config["TWOCAPTCHA_API_KEY"] = UPDATED_SECRET
@@ -67,6 +71,12 @@ def test_crawl_save_freezes_full_raw_persona_config_and_redacts_public_serializa
     runtime_config = get_config(crawl=crawl)
     assert runtime_config.USER_AGENT == "Frozen UA"
     assert runtime_config.TWOCAPTCHA_API_KEY == SENSITIVE_SECRET
+    execution_config = runtime_config.for_crawl()
+    assert execution_config["DEBUG"] is False
+    assert execution_config["CRAWL_DIR"] == str(crawl.output_dir)
+    assert "SECRET_KEY" not in execution_config
+    assert "PUBLIC_ADD_VIEW" not in execution_config
+    assert "DATABASE_NAME" not in execution_config
 
     public_json = crawl.to_json()
     assert public_json["config"]["TWOCAPTCHA_API_KEY"] == SENSITIVE_CONFIG_VALUE_REDACTED
@@ -115,12 +125,14 @@ def test_api_create_and_cli_add_store_full_frozen_config():
             tags_str="",
             label="API frozen config",
             notes="",
-            config={"TWOCAPTCHA_API_KEY": SENSITIVE_SECRET, "TIMEOUT": 33},
+            config={"TWOCAPTCHA_API_KEY": SENSITIVE_SECRET, "TIMEOUT": 33, "SECRET_KEY": "must-not-freeze", "PUBLIC_ADD_VIEW": True},
         ),
     )
     assert "CHECK_SSL_VALIDITY" in api_crawl.config
     assert api_crawl.config["TIMEOUT"] == 33
     assert api_crawl.config["TWOCAPTCHA_API_KEY"] == SENSITIVE_SECRET
+    assert "SECRET_KEY" not in api_crawl.config
+    assert "PUBLIC_ADD_VIEW" not in api_crawl.config
     assert CrawlSchema.resolve_config(api_crawl)["TWOCAPTCHA_API_KEY"] == SENSITIVE_CONFIG_VALUE_REDACTED
 
     cli_crawl, _snapshots = add(

--- a/archivebox/tests/test_frozen_crawl_config.py
+++ b/archivebox/tests/test_frozen_crawl_config.py
@@ -1,0 +1,160 @@
+import pytest
+from django.test import RequestFactory
+from django.utils import timezone
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+SENSITIVE_SECRET = "raw-twocaptcha-secret-for-frozen-crawl-test"
+UPDATED_SECRET = "updated-secret-that-must-not-affect-old-crawl"
+
+
+def _user(username="frozen-config-admin"):
+    from django.contrib.auth import get_user_model
+
+    return get_user_model().objects.create_superuser(
+        username=username,
+        email=f"{username}@example.com",
+        password="testpassword",
+    )
+
+
+def _persona(user, *, name="Frozen Persona", secret=SENSITIVE_SECRET, user_agent="Frozen UA"):
+    from archivebox.personas.models import Persona
+
+    persona = Persona.objects.create(
+        name=name,
+        created_by=user,
+        config={
+            "PERMISSIONS": "private",
+            "USER_AGENT": user_agent,
+            "TWOCAPTCHA_API_KEY": secret,
+            "DELETE_AFTER": "2h",
+        },
+    )
+    persona.ensure_dirs()
+    return persona
+
+
+def test_crawl_save_freezes_full_raw_persona_config_and_redacts_public_serialization():
+    from archivebox.config.common import SENSITIVE_CONFIG_VALUE_REDACTED, get_config
+    from archivebox.crawls.models import Crawl
+
+    user = _user()
+    persona = _persona(user)
+
+    crawl = Crawl.objects.create(
+        urls="https://example.com/frozen",
+        persona=persona,
+        created_by=user,
+        config={"CRAWL_MAX_CONCURRENT_SNAPSHOTS": 3},
+        status=Crawl.StatusChoices.QUEUED,
+        retry_at=timezone.now(),
+    )
+
+    assert "TIMEOUT" in crawl.config
+    assert "CHECK_SSL_VALIDITY" in crawl.config
+    assert crawl.config["USER_AGENT"] == "Frozen UA"
+    assert crawl.config["TWOCAPTCHA_API_KEY"] == SENSITIVE_SECRET
+    assert crawl.config["CRAWL_MAX_CONCURRENT_SNAPSHOTS"] == 3
+    assert "CRAWL_DIR" not in crawl.config
+    assert "SNAP_DIR" not in crawl.config
+
+    persona.config["USER_AGENT"] = "Mutated UA"
+    persona.config["TWOCAPTCHA_API_KEY"] = UPDATED_SECRET
+    persona.save(update_fields=["config"])
+
+    runtime_config = get_config(crawl=crawl)
+    assert runtime_config.USER_AGENT == "Frozen UA"
+    assert runtime_config.TWOCAPTCHA_API_KEY == SENSITIVE_SECRET
+
+    public_json = crawl.to_json()
+    assert public_json["config"]["TWOCAPTCHA_API_KEY"] == SENSITIVE_CONFIG_VALUE_REDACTED
+    assert SENSITIVE_SECRET not in str(public_json)
+
+
+def test_snapshot_config_overlays_frozen_crawl_without_re_reading_persona():
+    from archivebox.config.common import get_config
+    from archivebox.core.models import Snapshot
+    from archivebox.crawls.models import Crawl
+
+    user = _user("frozen-config-snapshot-admin")
+    persona = _persona(user, name="Frozen Snapshot Persona", user_agent="Crawl UA")
+    crawl = Crawl.objects.create(urls="https://example.com/root", persona=persona, created_by=user, config={"TIMEOUT": 11})
+    snapshot = Snapshot.objects.create(
+        url="https://example.com/root",
+        crawl=crawl,
+        config={"TIMEOUT": 22, "ANTHROPIC_API_KEY": "snapshot-secret"},
+    )
+
+    persona.config["TIMEOUT"] = 99
+    persona.save(update_fields=["config"])
+
+    runtime_config = get_config(crawl=crawl, snapshot=snapshot)
+    assert runtime_config.USER_AGENT == "Crawl UA"
+    assert runtime_config.TIMEOUT == 22
+    assert runtime_config.ANTHROPIC_API_KEY == "snapshot-secret"
+    assert snapshot.config == {"TIMEOUT": 22, "ANTHROPIC_API_KEY": "snapshot-secret"}
+
+
+def test_api_create_and_cli_add_store_full_frozen_config():
+    from archivebox.api.v1_crawls import CrawlCreateSchema, CrawlSchema, create_crawl
+    from archivebox.cli.archivebox_add import add
+    from archivebox.config.common import SENSITIVE_CONFIG_VALUE_REDACTED
+
+    user = _user("frozen-config-api-admin")
+    request = RequestFactory().post("/api/v1/crawls")
+    request.user = user
+
+    api_crawl = create_crawl(
+        request,
+        CrawlCreateSchema(
+            urls=["https://example.com/api"],
+            max_depth=0,
+            tags=[],
+            tags_str="",
+            label="API frozen config",
+            notes="",
+            config={"TWOCAPTCHA_API_KEY": SENSITIVE_SECRET, "TIMEOUT": 33},
+        ),
+    )
+    assert "CHECK_SSL_VALIDITY" in api_crawl.config
+    assert api_crawl.config["TIMEOUT"] == 33
+    assert api_crawl.config["TWOCAPTCHA_API_KEY"] == SENSITIVE_SECRET
+    assert CrawlSchema.resolve_config(api_crawl)["TWOCAPTCHA_API_KEY"] == SENSITIVE_CONFIG_VALUE_REDACTED
+
+    cli_crawl, _snapshots = add(
+        "https://example.com/cli",
+        bg=True,
+        created_by_id=user.pk,
+        config={"TWOCAPTCHA_API_KEY": SENSITIVE_SECRET, "TIMEOUT": 44},
+    )
+    assert "CHECK_SSL_VALIDITY" in cli_crawl.config
+    assert cli_crawl.config["TIMEOUT"] == 44
+    assert cli_crawl.config["TWOCAPTCHA_API_KEY"] == SENSITIVE_SECRET
+
+
+def test_schedule_enqueue_refreezes_using_current_template_persona_defaults():
+    from archivebox.crawls.models import Crawl, CrawlSchedule
+
+    user = _user("frozen-config-schedule-admin")
+    persona = _persona(user, name="Frozen Schedule Persona", user_agent="Initial schedule UA")
+    template = Crawl.objects.create(
+        urls="https://example.com/scheduled",
+        persona=persona,
+        created_by=user,
+        config={"TIMEOUT": 55},
+        status=Crawl.StatusChoices.PAUSED,
+    )
+    schedule = CrawlSchedule.objects.create(template=template, schedule="daily", created_by=user)
+
+    persona.config["USER_AGENT"] = "Current schedule UA"
+    persona.config["TWOCAPTCHA_API_KEY"] = UPDATED_SECRET
+    persona.save(update_fields=["config"])
+
+    child = schedule.enqueue()
+    assert child.config["TIMEOUT"] == 55
+    assert child.config["USER_AGENT"] == "Current schedule UA"
+    assert child.config["TWOCAPTCHA_API_KEY"] == UPDATED_SECRET
+    assert template.config["USER_AGENT"] == "Initial schedule UA"
+    assert template.config["TWOCAPTCHA_API_KEY"] == SENSITIVE_SECRET

--- a/archivebox/tests/test_ui_add_view.py
+++ b/archivebox/tests/test_ui_add_view.py
@@ -184,7 +184,7 @@ def test_add_view_creates_crawl_with_tag_and_url_filter_overrides(client, admin_
     assert crawl.config["CRAWL_MAX_CONCURRENT_SNAPSHOTS"] == 5
     assert crawl.config["URL_ALLOWLIST"] == "example.com\n*.example.com"
     assert crawl.config["URL_DENYLIST"] == "cdn.example.com"
-    assert "ONLY_NEW" not in crawl.config
+    assert crawl.config["ONLY_NEW"] is True
 
 
 def test_add_view_unchecked_only_new_sets_crawl_override(client, admin_user, monkeypatch):
@@ -253,7 +253,7 @@ def test_add_view_selected_persona_wins_over_stale_config_override(client, admin
     crawl = Crawl.objects.order_by("-created_at").first()
     assert crawl is not None
     assert crawl.persona_id == private_persona.id
-    assert "DEFAULT_PERSONA" not in crawl.config
+    assert crawl.config["ACTIVE_PERSONA"] == "Private"
     assert crawl.resolve_persona() == private_persona
     runtime_config = get_config(crawl=crawl)
     assert runtime_config.ACTIVE_PERSONA == "Private"
@@ -342,11 +342,11 @@ def test_add_view_public_submission_ignores_plugin_and_custom_config(client, adm
     assert crawl.config["CRAWL_MAX_CONCURRENT_SNAPSHOTS"] == 2
     assert crawl.config["URL_ALLOWLIST"] == "example.com"
     assert crawl.config["URL_DENYLIST"] == "cdn.example.com"
-    assert "PLUGINS" not in crawl.config
-    assert "WGET_TIMEOUT" not in crawl.config
-    assert "NODE_BINARY" not in crawl.config
-    assert "TWOCAPTCHA_API_KEY" not in crawl.config
-    assert "INDEX_ONLY" not in crawl.config
+    assert crawl.config.get("PLUGINS", "") == ""
+    assert crawl.config.get("WGET_TIMEOUT") != 77
+    assert crawl.config.get("NODE_BINARY") != "/tmp/node"
+    assert crawl.config.get("TWOCAPTCHA_API_KEY") != "posted-token"
+    assert crawl.config.get("INDEX_ONLY") is not True
     assert crawl.status == Crawl.StatusChoices.QUEUED
     assert crawl.schedule is None
 
@@ -417,7 +417,7 @@ def test_add_view_start_paused_creates_paused_crawl_without_snapshots(client, ad
     assert crawl.status == Crawl.StatusChoices.PAUSED
     assert crawl.retry_at == RETRY_AT_MAX
     assert crawl.snapshot_set.count() == 0
-    assert "INDEX_ONLY" not in crawl.config
+    assert crawl.config.get("INDEX_ONLY") is not True
 
 
 def test_add_view_extracts_urls_from_mixed_text_input(client, admin_user, monkeypatch):


### PR DESCRIPTION
### Motivation
- Prevent runtime behavior for an existing crawl from changing when user/persona/machine/global defaults mutate by storing a full resolved runtime config snapshot on each `Crawl.config` at creation time.
- Consolidate config masking (`********`) and plugin `x-sensitive` handling so outward-facing serialization and UI/admin views never leak raw secrets while hooks still receive raw values from the DB when running.

### Description
- Add `normalize_runtime_config()` and `build_crawl_config_snapshot()` helpers in `archivebox/config/common.py` to normalize config dicts and build the frozen snapshot stored on crawls, excluding runtime-only path keys like `CRAWL_DIR`/`SNAP_DIR`.
- Change `get_config()` semantics so when resolving with a `crawl` whose `config` is a frozen snapshot it is used as the base and the code no longer re-applies current persona/user/machine/env/file defaults underneath it.
- Freeze resolved config at crawl creation/save and on schedule enqueue by calling `build_crawl_config_snapshot()` from creation paths and `Crawl.save()` for new rows, and by re-freezing from current template defaults at `CrawlSchedule.enqueue()` time.
- Add a migration `crawls/migrations/0018_freeze_crawl_config_snapshots.py` that backfills existing `Crawl.config` rows with full frozen snapshots.
- Fold plugin schema `x-sensitive` keys into `is_sensitive_config_key()` and expose `SENSITIVE_CONFIG_VALUE_REDACTED = "********"` as the single placeholder; update plugin forms to treat blank or the placeholder as “keep existing secret” rather than clearing it.
- Replace `core.views.key_is_safe()` to delegate to the centralized `is_sensitive_config_key()` so UI debug views and REST schemas agree on masking behavior.
- Move runner/model runtime normalization to use the central `normalize_runtime_config()` and simplify some DELETE_AFTER candidate queries to rely on frozen crawl config.
- Add tests exercising the new behavior and expectations, including `archivebox/tests/test_frozen_crawl_config.py` which verifies: creating crawls via UI/API/CLI/schedule stores a full frozen config, raw secrets remain in DB for runtime, and public exports/redactions use `********`.

### Testing
- Compiled changed modules via `python -m py_compile` to ensure syntax correctness for updated helpers and call sites (succeeded).
- Ran the new frozen-config regression suite and related UI/API tests: `pytest -q archivebox/tests/test_frozen_crawl_config.py` and a selection of `archivebox/tests/test_ui_add_view.py` checks (all asserted tests passed in this environment: new tests and selected UI/API tests reported as passing).
- Exercised API and CLI creation paths: `create_crawl()` and the `archivebox add` code paths are covered in the new tests; the API-linked assertions passed in the test run.
- Note: a subprocess-based CLI fixture that shells out to the `archivebox` executable failed in this container because `archivebox` was not available on `PATH` (this is an environment/test harness issue, not a code regression); the in-process CLI `add()` call used by tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c9a8a979083219b347b18ba560932)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freezes each crawl’s resolved config and centralizes secret redaction with scoped configs. This stabilizes crawl behavior over time and hides secrets in APIs/UI while still providing raw values to runtime hooks.

- New Features
  - Store a full, normalized, scoped config snapshot on `Crawl.config` at creation/save and on schedule enqueue; excludes runtime/system-only keys (e.g., `CRAWL_DIR`, `SNAP_DIR`, `SECRET_KEY`, `DATABASE_NAME`).
  - Add config scopes and helpers: `for_crawl()`, `for_crawl_frozen_config()`, `normalize_runtime_config()`, and `build_crawl_config_snapshot()`.
  - Update `get_config()` to use the crawl’s frozen snapshot as the base and only reapply persona/user/machine/env/file defaults when resolving outside a crawl; adjust plugin config resolution accordingly.
  - Centralize sensitive-key detection (includes plugin `x-sensitive`) via `is_sensitive_config_key()` and a single `SENSITIVE_CONFIG_VALUE_REDACTED = "********"`; UI/API/debug share masking, forms treat blank or the placeholder as “keep existing”, and `core.views.key_is_safe()` now delegates to the central check.
  - Hooks/runner now pass scoped runtime config to plugins (no system-only keys), and `DELETE_AFTER` queries are simplified to rely on frozen crawl config.
  - Add tests covering UI/API/CLI/schedule paths, scoping, and redaction (`test_frozen_crawl_config.py`).

- Migration
  - Backfills existing crawls with frozen config snapshots (no manual steps).

<sup>Written for commit 2fb7d632c93216e004a5aa463fe6cb3323ba9250. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/ArchiveBox/pull/1810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

