### PR TITLE
Render yt-dlp media inline in snapshot cards

### DIFF
--- a/archivebox/core/models.py
+++ b/archivebox/core/models.py
@@ -4291,12 +4291,36 @@ class ArchiveResult(ModelWithDeleteAfter, ModelWithOutputDir, ModelWithNotes):
                 if Path(candidate).name.lower() == preferred_name:
                     return candidate
 
-        ext_groups = (
-            (".html", ".htm", ".mhtml", ".mht", ".pdf"),
-            (".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".ico"),
-            (".json", ".jsonl", ".txt", ".md", ".csv", ".tsv"),
-            (".mp4", ".webm", ".mp3", ".opus", ".ogg", ".wav"),
-        )
+        plugin_lower = (plugin_name or "").lower()
+        if plugin_lower in ("ytdlp", "yt-dlp", "youtube-dl"):
+            ext_groups = (
+                (".mp4", ".webm", ".m4v", ".ogv"),
+                (".mp3", ".m4a", ".aac", ".opus", ".ogg", ".wav", ".flac"),
+                (
+                    ".mkv",
+                    ".mov",
+                    ".avi",
+                    ".flv",
+                    ".wmv",
+                    ".mpg",
+                    ".mpeg",
+                    ".ts",
+                    ".m2ts",
+                    ".mts",
+                    ".3gp",
+                    ".3g2",
+                ),
+                (".html", ".htm", ".mhtml", ".mht", ".pdf"),
+                (".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".ico"),
+                (".json", ".jsonl", ".txt", ".md", ".csv", ".tsv", ".srt", ".vtt"),
+            )
+        else:
+            ext_groups = (
+                (".html", ".htm", ".mhtml", ".mht", ".pdf"),
+                (".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".ico"),
+                (".json", ".jsonl", ".txt", ".md", ".csv", ".tsv"),
+                (".mp4", ".webm", ".mp3", ".opus", ".ogg", ".wav"),
+            )
         for ext_group in ext_groups:
             group_candidates = [candidate for candidate in candidates if Path(candidate).suffix.lower() in ext_group]
             if group_candidates:

--- a/archivebox/core/templatetags/core_tags.py
+++ b/archivebox/core/templatetags/core_tags.py
@@ -3,7 +3,7 @@ from typing import Any
 from django import template
 from django.contrib.admin.templatetags.base import InclusionAdminNode
 from django.utils.safestring import mark_safe
-from django.utils.html import escape
+from django.utils.html import escape, format_html, format_html_join
 
 from pathlib import Path
 
@@ -30,7 +30,7 @@ _TEXT_PREVIEW_EXTS = (".json", ".jsonl", ".txt", ".csv", ".tsv", ".xml", ".yml",
 _IMAGE_PREVIEW_EXTS = (".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".ico", ".avif")
 _MHTML_PREVIEW_EXTS = (".mhtml", ".mht")
 
-_MEDIA_FILE_EXTS = {
+_VIDEO_FILE_EXTS = {
     ".mp4",
     ".webm",
     ".mkv",
@@ -47,6 +47,9 @@ _MEDIA_FILE_EXTS = {
     ".3gp",
     ".3g2",
     ".ogv",
+}
+
+_AUDIO_FILE_EXTS = {
     ".mp3",
     ".m4a",
     ".aac",
@@ -63,6 +66,10 @@ _MEDIA_FILE_EXTS = {
     ".eac3",
     ".dts",
 }
+
+_MEDIA_FILE_EXTS = _VIDEO_FILE_EXTS | _AUDIO_FILE_EXTS
+_BROWSER_VIDEO_FILE_EXTS = {".mp4", ".webm", ".m4v", ".ogv"}
+_BROWSER_AUDIO_FILE_EXTS = {".mp3", ".m4a", ".aac", ".ogg", ".oga", ".opus", ".wav", ".flac"}
 
 
 def _normalize_output_files(output_files: Any) -> dict[str, dict[str, Any]]:
@@ -157,16 +164,87 @@ def _list_media_files(result) -> list[dict]:
 
     for rel_path, size in candidates:
         href = str(Path(result.plugin) / rel_path)
+        suffix = rel_path.suffix.lower()
+        media_type = "video" if suffix in _VIDEO_FILE_EXTS else "audio"
+        is_browser_playable = suffix in _BROWSER_VIDEO_FILE_EXTS or suffix in _BROWSER_AUDIO_FILE_EXTS
         media_files.append(
             {
                 "name": rel_path.name,
                 "path": href,
                 "size": size,
+                "media_type": media_type,
+                "is_video": media_type == "video",
+                "is_audio": media_type == "audio",
+                "is_browser_playable": is_browser_playable,
             },
         )
 
-    media_files.sort(key=lambda item: item["name"].lower())
+    media_files.sort(
+        key=lambda item: (
+            0
+            if item["is_video"] and item["is_browser_playable"]
+            else 1
+            if item["is_audio"] and item["is_browser_playable"]
+            else 2,
+            -int(item.get("size") or 0),
+            item["name"].lower(),
+        ),
+    )
     return media_files
+
+
+def _render_ytdlp_media_card(media_files: list[dict], icon_html: str) -> str | None:
+    if not media_files:
+        return None
+
+    primary = next((item for item in media_files if item.get("is_video") and item.get("is_browser_playable")), None)
+    primary = primary or next((item for item in media_files if item.get("is_audio") and item.get("is_browser_playable")), None)
+    primary_url = (primary.get("url") or primary.get("path") or "") if primary else ""
+
+    if primary and primary_url and primary.get("is_video"):
+        player = format_html(
+            '<video class="card-img-top" data-no-preview="1" controls preload="metadata" src="{}" '
+            'style="width:100%; max-height:220px; background:#000; display:block;"></video>',
+            primary_url,
+        )
+    elif primary and primary_url and primary.get("is_audio"):
+        player = format_html(
+            '<div class="thumbnail-compact" data-plugin="ytdlp" style="pointer-events:auto;">'
+            '<span class="thumbnail-compact-icon">🎧</span>'
+            '<span class="thumbnail-compact-label">YT-DLP</span>'
+            '<audio data-no-preview="1" controls preload="metadata" src="{}" style="width:100%; margin-top:8px;"></audio>'
+            "</div>",
+            primary_url,
+        )
+    else:
+        player = mark_safe(
+            '<div class="thumbnail-compact" data-plugin="ytdlp" style="pointer-events:auto;">'
+            '<span class="thumbnail-compact-icon">🎬</span>'
+            '<span class="thumbnail-compact-label">YT-DLP</span>'
+            "</div>",
+        )
+
+    links = format_html_join(
+        "",
+        '<a href="{}" target="preview" title="{}">{} {}</a>',
+        (
+            (
+                item.get("url") or item.get("path") or "",
+                item.get("name") or "",
+                "🎬" if item.get("is_video") else "🎧",
+                item.get("name") or "",
+            )
+            for item in media_files
+            if item.get("url") or item.get("path")
+        ),
+    )
+
+    return format_html(
+        '<div class="ytdlp-media-card" style="pointer-events:auto;">{}'
+        '<div class="loose-items" style="pointer-events:auto;">{}</div></div>',
+        player,
+        links,
+    )
 
 
 def _resolve_snapshot_output_file(snapshot_dir: str | Path | None, raw_output_path: str | None) -> Path | None:
@@ -572,6 +650,9 @@ def plugin_card(context, result) -> str:
         for item in media_files:
             path = item.get("path") or ""
             item["url"] = build_snapshot_url(snapshot_id, path, request=request, config=config) if path else ""
+        ytdlp_card = _render_ytdlp_media_card(media_files, icon_html)
+        if ytdlp_card:
+            return mark_safe(ytdlp_card)
 
     output_lower = (raw_output_path or "").lower()
     force_text_preview = output_lower.endswith(_TEXT_PREVIEW_EXTS)

--- a/archivebox/tests/test_ui_admin_snapshot.py
+++ b/archivebox/tests/test_ui_admin_snapshot.py
@@ -246,9 +246,103 @@ class TestSnapshotProgressStats:
 
         assert _count_media_files(result) == 2
         assert _list_media_files(result) == [
-            {"name": "audio.mp3", "path": "ytdlp/audio.mp3", "size": 222},
-            {"name": "video.mp4", "path": "ytdlp/video.mp4", "size": 111},
+            {
+                "name": "video.mp4",
+                "path": "ytdlp/video.mp4",
+                "size": 111,
+                "media_type": "video",
+                "is_video": True,
+                "is_audio": False,
+                "is_browser_playable": True,
+            },
+            {
+                "name": "audio.mp3",
+                "path": "ytdlp/audio.mp3",
+                "size": 222,
+                "media_type": "audio",
+                "is_video": False,
+                "is_audio": True,
+                "is_browser_playable": True,
+            },
         ]
+
+    def test_ytdlp_discover_outputs_prefers_video_over_thumbnail(self, snapshot):
+        """YT-DLP snapshot cards should preview playable media before thumbnails."""
+        from archivebox.core.models import ArchiveResult
+
+        ArchiveResult.objects.create(
+            snapshot=snapshot,
+            plugin="ytdlp",
+            status="succeeded",
+            output_files={
+                "thumbnail.jpg": {"size": 9999, "mimetype": "image/jpeg", "extension": "jpg"},
+                "video.mp4": {"size": 111, "mimetype": "video/mp4", "extension": "mp4"},
+            },
+            output_size=10110,
+        )
+
+        outputs = snapshot.discover_outputs(include_filesystem_fallback=False)
+        ytdlp_output = next(output for output in outputs if output["name"] == "ytdlp")
+
+        assert ytdlp_output["path"] == "ytdlp/video.mp4"
+
+    def test_ytdlp_discover_outputs_prefers_browser_playable_video(self, snapshot):
+        """YT-DLP snapshot cards should not pick larger non-browser video over playable video."""
+        from archivebox.core.models import ArchiveResult
+
+        ArchiveResult.objects.create(
+            snapshot=snapshot,
+            plugin="ytdlp",
+            status="succeeded",
+            output_files={
+                "large.mkv": {"size": 9999, "mimetype": "video/x-matroska", "extension": "mkv"},
+                "small.mp4": {"size": 111, "mimetype": "video/mp4", "extension": "mp4"},
+            },
+            output_size=10110,
+        )
+
+        outputs = snapshot.discover_outputs(include_filesystem_fallback=False)
+        ytdlp_output = next(output for output in outputs if output["name"] == "ytdlp")
+
+        assert ytdlp_output["path"] == "ytdlp/small.mp4"
+
+    def test_ytdlp_plugin_card_renders_video_player(self, snapshot):
+        """YT-DLP cards should play archived videos inline instead of only listing downloads."""
+        from archivebox.core.models import ArchiveResult
+        from archivebox.core.templatetags import core_tags
+
+        result = ArchiveResult.objects.create(
+            snapshot=snapshot,
+            plugin="ytdlp",
+            status="succeeded",
+            output_files={"video.mp4": {"size": 111, "mimetype": "video/mp4", "extension": "mp4"}},
+            output_size=111,
+        )
+
+        html = str(core_tags.plugin_card({"request": None, "CONFIG": None}, result))
+
+        assert "<video" in html
+        assert "controls" in html
+        assert "ytdlp/video.mp4" in html
+
+    def test_ytdlp_plugin_card_links_non_browser_video_without_player(self, snapshot):
+        """Non-browser-playable videos should remain downloadable without rendering broken players."""
+        from archivebox.core.models import ArchiveResult
+        from archivebox.core.templatetags import core_tags
+
+        result = ArchiveResult.objects.create(
+            snapshot=snapshot,
+            plugin="ytdlp",
+            status="succeeded",
+            output_files={"video.mkv": {"size": 111, "mimetype": "video/x-matroska", "extension": "mkv"}},
+            output_size=111,
+        )
+
+        html = str(core_tags.plugin_card({"request": None, "CONFIG": None}, result))
+
+        assert "<video" not in html
+        assert "<audio" not in html
+        assert "ytdlp/video.mkv" in html
 
     def test_discover_outputs_falls_back_to_hashes_index_without_filesystem_walk(self, snapshot):
         """Older snapshots can still render cards from hashes.json when DB output_files are missing."""


### PR DESCRIPTION
## Summary
- render archived yt-dlp video/audio outputs inline in snapshot cards using native browser media controls
- prefer playable yt-dlp media over thumbnails/subtitle/metadata files when selecting the primary output path
- include media type metadata in yt-dlp media helper output and keep links to all downloaded media files

## Tests
- pytest archivebox/tests/test_ui_admin_snapshot.py -q

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render archived `ytdlp` videos and audio inline in snapshot cards using native media controls, only for browser‑playable formats. Prefer browser‑playable media for the main output and keep links to all downloaded files.

- **New Features**
  - Show an inline player for `ytdlp` results only when the file is browser‑playable (video first, then audio).
  - Prefer browser‑playable video/audio over thumbnails, metadata, and non‑playable containers for the main output.
  - Add media type flags (video/audio), sort with browser‑playable first then larger files, and expand media/subtitle extensions.
  - List links to all media files below the player.

<sup>Written for commit 2a0131b7abd7473b4ec1ae8feda487d2afcd9803. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/ArchiveBox/pull/1818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

