### PR TITLE
FIX: error 500 when trying to pause a crawl

### DIFF
--- a/archivebox/tests/test_crawl_pause.py
+++ b/archivebox/tests/test_crawl_pause.py
@@ -5,6 +5,9 @@ import time
 
 import pytest
 import requests
+from django.utils import timezone
+
+from archivebox.workers.models import RETRY_AT_MAX
 
 from .conftest import (
     build_test_env,
@@ -19,6 +22,11 @@ from .conftest import (
 )
 
 pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def test_retry_at_max_is_safe_for_admin_timezone_localization():
+    with timezone.override("Pacific/Kiritimati"):
+        assert timezone.localtime(RETRY_AT_MAX).year == 9999
 
 
 def wait_for_crawl_snapshot_rows(cwd, crawl_id, timeout=45):

--- a/archivebox/workers/models.py
+++ b/archivebox/workers/models.py
@@ -34,7 +34,7 @@ default_status_field: models.CharField = models.CharField(
     db_index=True,
 )
 default_retry_at_field: models.DateTimeField = models.DateTimeField(default=timezone.now, null=True, blank=True, db_index=True)
-RETRY_AT_MAX = datetime.max.replace(tzinfo=UTC)
+RETRY_AT_MAX = datetime(9999, 1, 1, tzinfo=UTC)
 ACTIVE_STATE_LEASE_SECONDS = 60
 logger = logging.getLogger(__name__)
 MODULE_PATH = Path(__file__).resolve()


### PR DESCRIPTION
Culprit:
Django admin localizes datetimes before rendering, and positive UTC offsets can overflow year 9999.

<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

Currently, if the system uses a timezone offset > UTC+0 , the max value used by the crawl job model can overflow when django is trying to render, causing internal server error.

This fix simply lowers the max value so that it does not overflow and adds a test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HTTP 500 when pausing a crawl by capping the retry timestamp to a safe max value so Django admin timezone localization doesn’t overflow on positive UTC offsets.

- **Bug Fixes**
  - Set `RETRY_AT_MAX` to `datetime(9999, 1, 1, tzinfo=UTC)` instead of `datetime.max`.
  - Added a test ensuring localization in `Pacific/Kiritimati` keeps the year at 9999.

<sup>Written for commit 766989eca32a25b88a01a82b1adf7df8c1ccbfa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/ArchiveBox/pull/1820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

