### PR TITLE
Update installation instructions for ArchiveBox

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ docker run -it -v $PWD:/data archivebox/archivebox init
 <br/>
 <br/>
 # Option C: Or install it with your preferred pkg manager (see Quickstart below for apt, brew, and more)
-pip install archivebox
+pip install archivebox legacy-cgi # cgi not part of python3.13 and above
 mkdir -p ~/archivebox/data && cd ~/archivebox/data
 archivebox init
-archivebox install
+archivebox setup
 # archivebox add 'https://example.com'
 # archivebox help
 # archivebox server 0.0.0.0:8000


### PR DESCRIPTION
`archivebox install` not functional, seems to be renamed to `archivebox setup`. from python3.13 we need `legacy-cgi`

<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

README-Install Option was not working for me
<!--e.g. This PR fixes ABC or adds the ability to do XYZ...-->

# Related issues

<!-- e.g. #123 or Roadmap goal # https://github.com/pirate/ArchiveBox/wiki/Roadmap -->

# Changes these areas

- [x] Bugfixes in README
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix README install steps for Python 3.13+ and current CLI. Replaces `archivebox install` with `archivebox setup` and adds `legacy-cgi` to the `pip install` command.

<sup>Written for commit f89314bec6ba2da716ee7201ed030db63990ade2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/ArchiveBox/pull/1822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

