### PR TITLE
fix: pass archive_results=[] to LiveBusUI.print_summary() in _run_install

### DIFF
--- a/archivebox/services/runner.py
+++ b/archivebox/services/runner.py
@@ -1952,7 +1952,7 @@ async def _run_install(plugin_names: list[str] | None = None) -> None:
                         await bus.destroy(clear=False)
                         bus_destroyed = True
             if live_ui is not None:
-                live_ui.print_summary(output_dir=output_dir)
+                live_ui.print_summary(output_dir=output_dir, archive_results=[])
     finally:
         if not bus_destroyed:
             await bus.destroy(clear=False)


### PR DESCRIPTION
Fixes #1825

`abx-dl` updated `LiveBusUI.print_summary()` to require `archive_results` as a keyword-only argument, but `_run_install` in `runner.py` wasn't updated to match. This caused a `TypeError` at the end of `archivebox init --install` after all binaries had already installed successfully — the install itself completed fine, only the summary display crashed.

Fix: pass `archive_results=[]` since the install path has no archive results.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash at the end of `archivebox init --install` by passing `archive_results=[]` to `LiveBusUI.print_summary()` in `_run_install`. Aligns with the new keyword-only signature in `abx-dl`, so installs complete and the summary renders without error.

<sup>Written for commit c28e3a98106b90bf5d77e7a9aa4134c681d4009f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/ArchiveBox/pull/1826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

