### PR TITLE
Allow same-origin OpenCode agent framing

### DIFF
--- a/archivebox/core/middleware.py
+++ b/archivebox/core/middleware.py
@@ -89,8 +89,13 @@ def AdminCookieIsolationMiddleware(get_response):
         response = get_response(request)
 
         if request.path == "/admin" or request.path.startswith("/admin/"):
-            response.headers["X-Frame-Options"] = "DENY"
-            response.headers["Content-Security-Policy"] = "frame-ancestors 'none'"
+            is_opencode_proxy = request.path == "/admin/agent/opencode" or request.path.startswith("/admin/agent/opencode/")
+            if is_opencode_proxy:
+                response.headers["X-Frame-Options"] = "SAMEORIGIN"
+                response.headers["Content-Security-Policy"] = "frame-ancestors 'self'"
+            else:
+                response.headers["X-Frame-Options"] = "DENY"
+                response.headers["Content-Security-Policy"] = "frame-ancestors 'none'"
 
         config = request.__dict__.get("archivebox_config")
         if config is None or config.SERVER_SECURITY_MODE == "auto":

--- a/archivebox/core/middleware.py
+++ b/archivebox/core/middleware.py
@@ -89,7 +89,9 @@ def AdminCookieIsolationMiddleware(get_response):
         response = get_response(request)
 
         if request.path == "/admin" or request.path.startswith("/admin/"):
-            is_opencode_proxy = request.path == "/admin/agent/opencode" or request.path.startswith("/admin/agent/opencode/")
+            from archivebox.opencode.views import _PROXY_PREFIX
+
+            is_opencode_proxy = request.path == _PROXY_PREFIX or request.path.startswith(f"{_PROXY_PREFIX}/")
             if is_opencode_proxy:
                 response.headers["X-Frame-Options"] = "SAMEORIGIN"
                 response.headers["Content-Security-Policy"] = "frame-ancestors 'self'"

--- a/archivebox/tests/test_opencode_agent.py
+++ b/archivebox/tests/test_opencode_agent.py
@@ -165,12 +165,24 @@ def test_opencode_agent_superuser_gets_admin_wrapper(admin_client, live_opencode
 
     response = admin_client.get("/admin/agent", HTTP_HOST=ADMIN_TEST_HOST)
     recent_session_id = views._recent_session_id(live_opencode.settings)
+    session_path = views._project_route(live_opencode.config.data_dir, recent_session_id)
 
     assert response.status_code == 200
     assert recent_session_id
-    assert f'<iframe src="{views._project_route(live_opencode.config.data_dir, recent_session_id)}"'.encode() in response.content
+    assert f'<iframe src="{session_path}"'.encode() in response.content
     assert b'id="header"' in response.content
     assert b'id="progress-monitor"' in response.content
+    assert response.headers["X-Frame-Options"] == "DENY"
+    assert response.headers["Content-Security-Policy"] == "frame-ancestors 'none'"
+
+    session = admin_client.get(
+        session_path,
+        HTTP_HOST=ADMIN_TEST_HOST,
+        HTTP_SEC_FETCH_SITE="same-origin",
+    )
+    assert session.status_code == 200
+    assert session.headers["X-Frame-Options"] == "SAMEORIGIN"
+    assert session.headers["Content-Security-Policy"] == "frame-ancestors 'self'"
 
 
 def test_opencode_proxy_serves_real_project_and_session(admin_client, live_opencode):


### PR DESCRIPTION
Fix the embedded AI agent UI being blocked by the global admin framing policy.

- preserve `DENY` / `frame-ancestors 'none'` for the agent wrapper and all other admin routes
- allow only `/admin/agent/opencode...` to frame on the same origin
- cover the real proxied OpenCode session response in the integration test

Verified: `uv run pytest archivebox/tests/test_opencode_agent.py archivebox/tests/test_ui_add_view.py::test_add_view_hides_agent_link_when_opencode_is_disabled archivebox/tests/test_ui_admin_links.py::test_admin_navigation_hides_agent_link_when_opencode_is_disabled -q` (12 passed), plus prek on both changed files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the embedded OpenCode AI agent UI being blocked by the global admin framing policy. Previously, all `/admin` routes sent `X-Frame-Options: DENY` and `frame-ancestors 'none'`; OpenCode proxy paths now allow same-origin framing, while the admin wrapper and all other admin routes keep the strict policy.

- Keys the framing exception off the OpenCode proxy prefix instead of a hardcoded admin route.
- Extends the integration test to verify the real proxied session response allows same-origin framing.

<sup>Written for commit 185eb71b85316a805cfe9f8cb05ca76c75418c2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/ArchiveBox/pull/1855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

