### PR TITLE
Avoid OpenCode proxy startup stalls

### DIFF
--- a/archivebox/opencode/views.py
+++ b/archivebox/opencode/views.py
@@ -31,6 +31,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 _PROCESS: subprocess.Popen | None = None
 _PROCESS_LOCK = threading.Lock()
+_SESSION_LOCK = threading.Lock()
 _PROXY_PREFIX = "/admin/agent/opencode"
 _PROXY_PREFIX_REGEX = _PROXY_PREFIX.replace("/", r"\/")
 _PROXY_PREFIX_NO_SLASH_REGEX = _PROXY_PREFIX.lstrip("/").replace("/", r"\/")
@@ -477,7 +478,8 @@ def agent_view(request: HttpRequest):
     recent_session_id = ""
     if ok:
         try:
-            recent_session_id = _ensure_default_session(settings)
+            with _SESSION_LOCK:
+                recent_session_id = _ensure_default_session(settings)
         except (requests.RequestException, RuntimeError, ValueError) as err:
             ok = False
             error = f"OpenCode project initialization failed: {err}"
@@ -659,36 +661,25 @@ def opencode_proxy_view(request: HttpRequest, path: str | None = None):
             content_type="text/plain; charset=utf-8",
         )
 
+    try:
+        body = upstream.content
+    except requests.RequestException as err:
+        upstream.close()
+        return HttpResponse(
+            str(err).encode(),
+            status=502,
+            content_type="text/plain; charset=utf-8",
+        )
+
     content_type = upstream.headers.get("Content-Type", "")
-    is_event_stream = content_type.startswith("text/event-stream")
-    is_json = content_type.startswith("application/json")
-    is_text = not is_event_stream and any(content_type.startswith(prefix) for prefix in _TEXT_CONTENT_TYPES)
     headers = _response_headers(upstream, settings)
-    if is_text:
-        body = _rewrite_text(upstream.content, settings)
-        response = HttpResponse(
-            body,
-            status=upstream.status_code,
-            content_type=content_type or "text/plain; charset=utf-8",
-        )
-    elif is_json:
-        response = HttpResponse(
-            upstream.content,
-            status=upstream.status_code,
-            content_type=content_type,
-        )
-    elif is_event_stream:
-        response = StreamingHttpResponse(
-            upstream.iter_lines(chunk_size=1),
-            status=upstream.status_code,
-            content_type=content_type or "text/event-stream",
-        )
-    else:
-        response = StreamingHttpResponse(
-            upstream.iter_content(chunk_size=64 * 1024),
-            status=upstream.status_code,
-            content_type=content_type or "application/octet-stream",
-        )
+    if any(content_type.startswith(prefix) for prefix in _TEXT_CONTENT_TYPES):
+        body = _rewrite_text(body, settings)
+    response = HttpResponse(
+        body,
+        status=upstream.status_code,
+        content_type=content_type or "application/octet-stream",
+    )
     for key, value in headers.items():
         response.headers[key] = value
     response.headers["Cache-Control"] = "no-store"

--- a/archivebox/opencode/views.py
+++ b/archivebox/opencode/views.py
@@ -39,7 +39,6 @@ _CONFIG_PATH = Path(opencode_plugin.__file__).with_name("config.json")
 _TEXT_CONTENT_TYPES = (
     "text/",
     "application/javascript",
-    "application/json",
     "application/x-javascript",
 )
 _HOP_BY_HOP_HEADERS = {
@@ -196,11 +195,11 @@ def _settings(config: dict) -> dict:
     host = str(_config_value(config, "OPENCODE_HOST", "127.0.0.1"))
     port = int(_config_value(config, "OPENCODE_PORT", 4096))
     default_data_dir = _archivebox_data_dir_default()
-    workdir = Path(
-        str(_config_value(config, "OPENCODE_WORKDIR", default_data_dir)),
-    ).expanduser()
     opencode_dir = Path(
-        str(_config_value(config, "OPENCODE_STATE_DIR", workdir / "opencode")),
+        str(_config_value(config, "OPENCODE_STATE_DIR", default_data_dir / "opencode")),
+    ).expanduser()
+    workdir = Path(
+        str(_config_value(config, "OPENCODE_WORKDIR", opencode_dir / "workdir")),
     ).expanduser()
     binary = str(_config_value(config, "OPENCODE_BINARY", "opencode"))
     timeout = int(_config_value(config, "OPENCODE_TIMEOUT", 30))
@@ -208,6 +207,7 @@ def _settings(config: dict) -> dict:
         "host": host,
         "port": port,
         "origin": f"http://{host}:{port}",
+        "archivebox_data_dir": default_data_dir,
         "workdir": workdir,
         "opencode_dir": opencode_dir,
         "config_home": opencode_dir / "config",
@@ -287,7 +287,7 @@ def _ensure_project_files(settings: dict) -> None:
     if not editable_skill_path.exists():
         editable_skill_path.write_text(
             _ARCHIVEBOX_SKILL.format(
-                archivebox_data_dir=workdir,
+                archivebox_data_dir=settings["archivebox_data_dir"],
                 archivebox_base_url=settings.get("archivebox_base_url", ""),
                 archivebox_admin_url=settings.get("archivebox_admin_url", ""),
                 archivebox_api_url=settings.get("archivebox_api_url", ""),
@@ -350,23 +350,6 @@ def _ensure_default_session(settings: dict) -> str:
             "OpenCode did not create a session for the requested worktree.",
         )
     return session_id
-
-
-def _recent_session_id(settings: dict) -> str:
-    workdir = str(settings["workdir"].resolve())
-    try:
-        response = requests.get(
-            f"{settings['origin']}/session",
-            params={"directory": workdir, "roots": "true", "limit": 1},
-            timeout=settings["timeout"],
-        )
-        response.raise_for_status()
-        sessions = response.json()
-        if sessions:
-            return str(sessions[0].get("id") or "")
-    except requests.RequestException:
-        pass
-    return ""
 
 
 def _health(settings: dict) -> bool:
@@ -435,10 +418,6 @@ def _ensure_opencode(settings: dict) -> tuple[bool, str]:
                 )
 
         if _health(settings):
-            try:
-                _ensure_default_session(settings)
-            except (requests.RequestException, RuntimeError, ValueError) as err:
-                return False, f"OpenCode project initialization failed: {err}"
             return True, ""
 
         binary_abspath = binary.loaded_abspath
@@ -461,7 +440,6 @@ def _ensure_opencode(settings: dict) -> tuple[bool, str]:
                 env=env,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
                 start_new_session=True,
             )
             started_process = _PROCESS
@@ -471,11 +449,6 @@ def _ensure_opencode(settings: dict) -> tuple[bool, str]:
         deadline = time.monotonic() + settings["timeout"]
         while time.monotonic() < deadline:
             if _health(settings):
-                try:
-                    _ensure_default_session(settings)
-                except (requests.RequestException, RuntimeError, ValueError) as err:
-                    _stop_owned_process(started_process)
-                    return False, f"OpenCode project initialization failed: {err}"
                 return True, ""
             if started_process and started_process.poll() is not None:
                 if _PROCESS is started_process:
@@ -501,9 +474,15 @@ def agent_view(request: HttpRequest):
     settings["archivebox_admin_url"] = admin_url
     settings["archivebox_api_url"] = api_url
     ok, error = _ensure_opencode(settings)
+    recent_session_id = ""
+    if ok:
+        try:
+            recent_session_id = _ensure_default_session(settings)
+        except (requests.RequestException, RuntimeError, ValueError) as err:
+            ok = False
+            error = f"OpenCode project initialization failed: {err}"
     from archivebox.core.admin_site import archivebox_admin
 
-    recent_session_id = _recent_session_id(settings) if ok else ""
     context = {
         **archivebox_admin.each_context(request),
         "title": "Agent",
@@ -651,13 +630,6 @@ def opencode_proxy_view(request: HttpRequest, path: str | None = None):
     settings["archivebox_base_url"] = base_url
     settings["archivebox_admin_url"] = admin_url
     settings["archivebox_api_url"] = api_url
-    ok, error = _ensure_opencode(settings)
-    if not ok:
-        return HttpResponse(
-            error.encode(),
-            status=502,
-            content_type="text/plain; charset=utf-8",
-        )
 
     if request.method == "GET" and (path or "").endswith("/event"):
         response = StreamingHttpResponse(
@@ -677,7 +649,7 @@ def opencode_proxy_view(request: HttpRequest, path: str | None = None):
             data=request.body if method not in {"GET", "HEAD"} else None,
             headers=_request_headers(request, settings),
             stream=True,
-            timeout=(settings["timeout"], None),
+            timeout=settings["timeout"],
             allow_redirects=False,
         )
     except requests.RequestException as err:
@@ -689,6 +661,7 @@ def opencode_proxy_view(request: HttpRequest, path: str | None = None):
 
     content_type = upstream.headers.get("Content-Type", "")
     is_event_stream = content_type.startswith("text/event-stream")
+    is_json = content_type.startswith("application/json")
     is_text = not is_event_stream and any(content_type.startswith(prefix) for prefix in _TEXT_CONTENT_TYPES)
     headers = _response_headers(upstream, settings)
     if is_text:
@@ -697,6 +670,12 @@ def opencode_proxy_view(request: HttpRequest, path: str | None = None):
             body,
             status=upstream.status_code,
             content_type=content_type or "text/plain; charset=utf-8",
+        )
+    elif is_json:
+        response = HttpResponse(
+            upstream.content,
+            status=upstream.status_code,
+            content_type=content_type,
         )
     elif is_event_stream:
         response = StreamingHttpResponse(

--- a/archivebox/opencode/views.py
+++ b/archivebox/opencode/views.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import atexit
 import base64
+import logging
 import os
 import re
 import shutil
@@ -32,6 +33,7 @@ from django.views.decorators.csrf import csrf_exempt
 _PROCESS: subprocess.Popen | None = None
 _PROCESS_LOCK = threading.Lock()
 _SESSION_LOCK = threading.Lock()
+_LOGGER = logging.getLogger(__name__)
 _PROXY_PREFIX = "/admin/agent/opencode"
 _PROXY_PREFIX_REGEX = _PROXY_PREFIX.replace("/", r"\/")
 _PROXY_PREFIX_NO_SLASH_REGEX = _PROXY_PREFIX.lstrip("/").replace("/", r"\/")
@@ -614,6 +616,15 @@ def _response_headers(upstream: requests.Response, settings: dict) -> dict[str, 
     return headers
 
 
+def _proxy_error_response(error: requests.RequestException) -> HttpResponse:
+    _LOGGER.warning("OpenCode upstream request failed: %s", error)
+    return HttpResponse(
+        b"OpenCode upstream request failed.",
+        status=502,
+        content_type="text/plain; charset=utf-8",
+    )
+
+
 @csrf_exempt
 def opencode_proxy_view(request: HttpRequest, path: str | None = None):
     config = _machine_config()
@@ -655,21 +666,13 @@ def opencode_proxy_view(request: HttpRequest, path: str | None = None):
             allow_redirects=False,
         )
     except requests.RequestException as err:
-        return HttpResponse(
-            str(err).encode(),
-            status=502,
-            content_type="text/plain; charset=utf-8",
-        )
+        return _proxy_error_response(err)
 
     try:
         body = upstream.content
     except requests.RequestException as err:
         upstream.close()
-        return HttpResponse(
-            str(err).encode(),
-            status=502,
-            content_type="text/plain; charset=utf-8",
-        )
+        return _proxy_error_response(err)
 
     content_type = upstream.headers.get("Content-Type", "")
     headers = _response_headers(upstream, settings)

--- a/archivebox/tests/test_opencode_agent.py
+++ b/archivebox/tests/test_opencode_agent.py
@@ -164,7 +164,7 @@ def test_opencode_agent_superuser_gets_admin_wrapper(admin_client, live_opencode
     from archivebox.opencode import views
 
     response = admin_client.get("/admin/agent", HTTP_HOST=ADMIN_TEST_HOST)
-    recent_session_id = views._recent_session_id(live_opencode.settings)
+    recent_session_id = response.context["recent_session_id"]
     session_path = views._project_route(live_opencode.config.data_dir, recent_session_id)
 
     assert response.status_code == 200
@@ -188,6 +188,9 @@ def test_opencode_agent_superuser_gets_admin_wrapper(admin_client, live_opencode
 def test_opencode_proxy_serves_real_project_and_session(admin_client, live_opencode):
     workdir = str(live_opencode.config.data_dir.resolve())
     encoded_workdir = quote(workdir)
+
+    agent = admin_client.get("/admin/agent", HTTP_HOST=ADMIN_TEST_HOST)
+    assert agent.status_code == 200
 
     project = admin_client.get(
         f"/admin/agent/opencode/project/current?directory={encoded_workdir}",
@@ -250,21 +253,36 @@ def test_opencode_starts_with_isolated_state(live_opencode):
 def test_opencode_state_dir_is_separate_from_workdir(tmp_path):
     from archivebox.opencode import views
 
-    workdir = tmp_path / "data"
-    settings = views._settings({"OPENCODE_WORKDIR": str(workdir)})
+    workdir = tmp_path / "workdir"
+    state_dir = tmp_path / "state"
+    settings = views._settings(
+        {
+            "OPENCODE_WORKDIR": str(workdir),
+            "OPENCODE_STATE_DIR": str(state_dir),
+        },
+    )
     views._ensure_project_files(settings)
 
     assert settings["workdir"] == workdir
-    assert settings["opencode_dir"] == workdir / "opencode"
-    assert settings["config_home"] == workdir / "opencode" / "config"
-    assert settings["data_home"] == workdir / "opencode" / "data"
-    assert settings["state_home"] == workdir / "opencode" / "state"
-    editable_skill = workdir / "opencode" / "SKILL.md"
-    loaded_skill = workdir / "opencode" / "config" / "opencode" / "skills" / "archivebox" / "SKILL.md"
+    assert settings["opencode_dir"] == state_dir
+    assert settings["config_home"] == state_dir / "config"
+    assert settings["data_home"] == state_dir / "data"
+    assert settings["state_home"] == state_dir / "state"
+    editable_skill = state_dir / "SKILL.md"
+    loaded_skill = state_dir / "config" / "opencode" / "skills" / "archivebox" / "SKILL.md"
     assert editable_skill.exists()
     assert loaded_skill.is_symlink()
     assert loaded_skill.resolve() == editable_skill.resolve()
-    assert f"ArchiveBox collection directory: {workdir.resolve()}" in editable_skill.read_text()
+    assert f"ArchiveBox collection directory: {settings['archivebox_data_dir']}" in editable_skill.read_text()
+
+
+def test_opencode_default_workdir_does_not_scan_the_collection():
+    from archivebox.opencode import views
+
+    settings = views._settings({})
+
+    assert settings["opencode_dir"] == settings["archivebox_data_dir"] / "opencode"
+    assert settings["workdir"] == settings["opencode_dir"] / "workdir"
 
 
 def test_opencode_rewrites_vite_preload_assets():


### PR DESCRIPTION
Fix the remaining `/admin/agent` startup failures found on DigestBox after enabling the feature.

- initialize the OpenCode project/session once from the outer agent route instead of once per parallel proxy request
- default the OpenCode project to `DATA_DIR/opencode/workdir`, keeping million-snapshot collections out of file/VCS scans
- pass JSON API responses through without frontend source rewriting
- bound normal upstream reads while retaining unbounded SSE reads
- preserve OpenCode stderr in ArchiveBox logs
- remove the redundant recent-session request/helper

Validation:
- `uv run pytest archivebox/tests/test_opencode_agent.py archivebox/tests/test_ui_add_view.py::test_add_view_hides_agent_link_when_opencode_is_disabled archivebox/tests/test_ui_admin_links.py::test_admin_navigation_hides_agent_link_when_opencode_is_disabled -q` (13 passed)
- `uv run prek run --files archivebox/opencode/views.py archivebox/tests/test_opencode_agent.py`
- live DigestBox cold-load spot check: prompt rendered, no proxy 502s or file-scan timeout after moving the project workdir out of the collection root

Config documentation companion: ArchiveBox/abx-plugins#61

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `/admin/agent` startup stalls by moving OpenCode project and session initialization out of proxy requests and into the agent page load, where concurrent initialization is serialized. The default workdir now lives at `DATA_DIR/opencode/workdir` instead of the collection directory, avoiding expensive scans on large snapshots.

- Proxy upstream failures are logged server-side and returned as generic 502 responses.
- JSON API responses pass through unchanged; normal reads use bounded timeouts while SSE reads remain unbounded.
- OpenCode stderr remains in ArchiveBox logs, and the redundant recent-session lookup is removed.

<sup>Written for commit ca8d5ffc8864b97fcf8f9f2f9dd477a62a751b3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/ArchiveBox/pull/1856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

