### PR TITLE
Keep embedded OpenCode proxy resilient

### DIFF
--- a/archivebox/opencode/views.py
+++ b/archivebox/opencode/views.py
@@ -371,9 +371,6 @@ def _ensure_opencode(settings: dict) -> tuple[bool, str]:
     started_process: subprocess.Popen | None = None
     workdir = settings["workdir"].resolve()
 
-    if (_PROCESS is not None and _PROCESS.poll() is None) or _health(settings):
-        return True, ""
-
     with _PROCESS_LOCK:
         if (_PROCESS is not None and _PROCESS.poll() is None) or _health(settings):
             return True, ""

--- a/archivebox/opencode/views.py
+++ b/archivebox/opencode/views.py
@@ -205,7 +205,7 @@ def _settings(config: dict) -> dict:
         str(_config_value(config, "OPENCODE_WORKDIR", opencode_dir / "workdir")),
     ).expanduser()
     binary = str(_config_value(config, "OPENCODE_BINARY", "opencode"))
-    timeout = int(_config_value(config, "OPENCODE_TIMEOUT", 30))
+    timeout = int(_config_value(config, "OPENCODE_TIMEOUT", 120))
     return {
         "host": host,
         "port": port,
@@ -370,31 +370,38 @@ def _ensure_opencode(settings: dict) -> tuple[bool, str]:
     global _PROCESS
     started_process: subprocess.Popen | None = None
     workdir = settings["workdir"].resolve()
-    try:
-        binary, git_binary, binary_env = _resolve_binary(
-            settings["binary"],
-            settings["config"],
-        )
-    except RuntimeError as err:
-        return False, str(err)
 
-    env = {
-        **os.environ,
-        **binary_env,
-        "ARCHIVEBOX_BASE_URL": str(settings.get("archivebox_base_url", "")),
-        "ARCHIVEBOX_ADMIN_URL": str(settings.get("archivebox_admin_url", "")),
-        "ARCHIVEBOX_API_URL": str(settings.get("archivebox_api_url", "")),
-        "BROWSER": "false",
-        "GIT_CEILING_DIRECTORIES": str(workdir),
-        "HOME": str(settings["home"]),
-        "OPENCODE_DISABLE_PROJECT_CONFIG": "true",
-        "XDG_CONFIG_HOME": str(settings["config_home"]),
-        "XDG_DATA_HOME": str(settings["data_home"]),
-        "XDG_STATE_HOME": str(settings["state_home"]),
-        "XDG_CACHE_HOME": str(settings["cache_home"]),
-    }
+    if (_PROCESS is not None and _PROCESS.poll() is None) or _health(settings):
+        return True, ""
 
     with _PROCESS_LOCK:
+        if (_PROCESS is not None and _PROCESS.poll() is None) or _health(settings):
+            return True, ""
+
+        try:
+            binary, git_binary, binary_env = _resolve_binary(
+                settings["binary"],
+                settings["config"],
+            )
+        except RuntimeError as err:
+            return False, str(err)
+
+        env = {
+            **os.environ,
+            **binary_env,
+            "ARCHIVEBOX_BASE_URL": str(settings.get("archivebox_base_url", "")),
+            "ARCHIVEBOX_ADMIN_URL": str(settings.get("archivebox_admin_url", "")),
+            "ARCHIVEBOX_API_URL": str(settings.get("archivebox_api_url", "")),
+            "BROWSER": "false",
+            "GIT_CEILING_DIRECTORIES": str(workdir),
+            "HOME": str(settings["home"]),
+            "OPENCODE_DISABLE_PROJECT_CONFIG": "true",
+            "XDG_CONFIG_HOME": str(settings["config_home"]),
+            "XDG_DATA_HOME": str(settings["data_home"]),
+            "XDG_STATE_HOME": str(settings["state_home"]),
+            "XDG_CACHE_HOME": str(settings["cache_home"]),
+        }
+
         settings["workdir"].mkdir(parents=True, exist_ok=True)
         settings["config_home"].mkdir(parents=True, exist_ok=True)
         settings["data_home"].mkdir(parents=True, exist_ok=True)
@@ -544,15 +551,18 @@ async def _event_chunks(request: HttpRequest, settings: dict, path: str | None):
     timeout = httpx.Timeout(settings["timeout"], read=None)
     url = _proxy_url(settings, path)
     method = request.method or "GET"
-    async with httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client:
-        async with client.stream(
-            method,
-            url,
-            params=_request_params(request),
-            headers=_request_headers(request, settings),
-        ) as upstream:
-            async for chunk in upstream.aiter_raw(chunk_size=512):
-                yield chunk
+    try:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client:
+            async with client.stream(
+                method,
+                url,
+                params=_request_params(request),
+                headers=_request_headers(request, settings),
+            ) as upstream:
+                async for chunk in upstream.aiter_raw(chunk_size=512):
+                    yield chunk
+    except httpx.RequestError as err:
+        _LOGGER.warning("OpenCode event stream ended: %s", err)
 
 
 def _rewrite_text(body: bytes, settings: dict) -> bytes:
@@ -616,7 +626,7 @@ def _response_headers(upstream: requests.Response, settings: dict) -> dict[str, 
     return headers
 
 
-def _proxy_error_response(error: requests.RequestException) -> HttpResponse:
+def _proxy_error_response(error: Exception | str) -> HttpResponse:
     _LOGGER.warning("OpenCode upstream request failed: %s", error)
     return HttpResponse(
         b"OpenCode upstream request failed.",
@@ -643,6 +653,10 @@ def opencode_proxy_view(request: HttpRequest, path: str | None = None):
     settings["archivebox_base_url"] = base_url
     settings["archivebox_admin_url"] = admin_url
     settings["archivebox_api_url"] = api_url
+
+    ok, error = _ensure_opencode(settings)
+    if not ok:
+        return _proxy_error_response(error)
 
     if request.method == "GET" and (path or "").endswith("/event"):
         response = StreamingHttpResponse(

--- a/archivebox/tests/test_opencode_agent.py
+++ b/archivebox/tests/test_opencode_agent.py
@@ -1,5 +1,6 @@
 import os
 import socket
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 from urllib.parse import quote
@@ -233,6 +234,18 @@ def test_opencode_proxy_restarts_server_for_an_existing_agent_page(admin_client,
     assert views._PROCESS is not None
     assert views._PROCESS is not old_process
     assert views._PROCESS.poll() is None
+
+
+def test_concurrent_opencode_startup_waits_until_server_is_ready(live_opencode):
+    from archivebox.opencode import views
+
+    views._stop_owned_process()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(views._ensure_opencode, [live_opencode.settings] * 2))
+
+    assert results == [(True, ""), (True, "")]
+    assert views._health(live_opencode.settings)
 
 
 def test_opencode_proxy_sse_response_is_unbuffered(admin_client, live_opencode):

--- a/archivebox/tests/test_opencode_agent.py
+++ b/archivebox/tests/test_opencode_agent.py
@@ -217,6 +217,24 @@ def test_opencode_proxy_serves_real_project_and_session(admin_client, live_openc
     assert b"id" in sessions.content
 
 
+def test_opencode_proxy_restarts_server_for_an_existing_agent_page(admin_client, live_opencode):
+    from archivebox.opencode import views
+
+    old_process = views._PROCESS
+    views._stop_owned_process()
+
+    response = admin_client.get(
+        "/admin/agent/opencode/global/health",
+        HTTP_HOST=ADMIN_TEST_HOST,
+        HTTP_SEC_FETCH_SITE="same-origin",
+    )
+
+    assert response.status_code == 200
+    assert views._PROCESS is not None
+    assert views._PROCESS is not old_process
+    assert views._PROCESS.poll() is None
+
+
 def test_opencode_proxy_sse_response_is_unbuffered(admin_client, live_opencode):
     response = admin_client.get(
         "/admin/agent/opencode/global/event",
@@ -283,6 +301,7 @@ def test_opencode_default_workdir_does_not_scan_the_collection():
 
     assert settings["opencode_dir"] == settings["archivebox_data_dir"] / "opencode"
     assert settings["workdir"] == settings["opencode_dir"] / "workdir"
+    assert settings["timeout"] == 120
 
 
 def test_opencode_rewrites_vite_preload_assets():


### PR DESCRIPTION
Make the embedded OpenCode proxy recover after an ArchiveBox/OpenCode restart and tolerate OpenCode 1.17's slow cold provider-catalog response.

- lazily ensure OpenCode for proxy requests, so already-open agent tabs recover after restarts
- bypass dependency resolution entirely while the owned server process is alive
- serialize cold dependency resolution/startup under the existing process lock
- close failed SSE connections cleanly instead of leaking an ASGI traceback
- use the matching 120s fallback for the existing `OPENCODE_TIMEOUT` setting

No new runtime class, plan API, config knob, compatibility path, or ArchiveResult orchestration was added.

Verified with real OpenCode subprocesses:
- `uv run pytest archivebox/tests/test_opencode_agent.py archivebox/tests/test_ui_add_view.py::test_add_view_hides_agent_link_when_opencode_is_disabled archivebox/tests/test_ui_admin_links.py::test_admin_navigation_hides_agent_link_when_opencode_is_disabled -q` (14 passed)
- `uv run prek run --files archivebox/opencode/views.py archivebox/tests/test_opencode_agent.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the embedded OpenCode proxy resilient to ArchiveBox/OpenCode restarts and OpenCode 1.17's slow cold provider-catalog response.

- Lazily starts OpenCode on proxy requests so already-open agent tabs recover after restarts.
- Skips dependency resolution while the owned server process is alive.
- Serializes cold startup under the existing process lock and waits until the server is ready before returning.
- Closes failed SSE connections cleanly instead of leaking an ASGI traceback.
- Raises the default `OPENCODE_TIMEOUT` fallback from 30s to 120s to match the slow cold response.

<sup>Written for commit f0699c56ad8e8ea77218e512401a06ec55ba74b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/ArchiveBox/pull/1857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

