### PR TITLE
Stop the full OpenCode process group

### DIFF
--- a/archivebox/opencode/views.py
+++ b/archivebox/opencode/views.py
@@ -86,23 +86,27 @@ You are running inside an ArchiveBox collection directory.
 """
 
 
+def _signal_owned_process(process: subprocess.Popen, sig: signal.Signals) -> None:
+    try:
+        os.killpg(process.pid, sig)
+    except OSError:
+        try:
+            process.send_signal(sig)
+        except ProcessLookupError:
+            pass
+
+
 def _stop_owned_process(process: subprocess.Popen | None = None) -> None:
     global _PROCESS
     owned_process = process or _PROCESS
     if owned_process is None:
         return
     if owned_process.poll() is None:
-        try:
-            os.killpg(owned_process.pid, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
+        _signal_owned_process(owned_process, signal.SIGTERM)
         try:
             owned_process.wait(timeout=5)
         except subprocess.TimeoutExpired:
-            try:
-                os.killpg(owned_process.pid, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
+            _signal_owned_process(owned_process, signal.SIGKILL)
             owned_process.wait()
     if _PROCESS is owned_process:
         _PROCESS = None

--- a/archivebox/opencode/views.py
+++ b/archivebox/opencode/views.py
@@ -5,6 +5,7 @@ import base64
 import logging
 import os
 import re
+import signal
 import shutil
 import subprocess
 import threading
@@ -91,11 +92,17 @@ def _stop_owned_process(process: subprocess.Popen | None = None) -> None:
     if owned_process is None:
         return
     if owned_process.poll() is None:
-        owned_process.terminate()
+        try:
+            os.killpg(owned_process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
         try:
             owned_process.wait(timeout=5)
         except subprocess.TimeoutExpired:
-            owned_process.kill()
+            try:
+                os.killpg(owned_process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
             owned_process.wait()
     if _PROCESS is owned_process:
         _PROCESS = None

--- a/archivebox/tests/test_opencode_agent.py
+++ b/archivebox/tests/test_opencode_agent.py
@@ -128,9 +128,13 @@ def test_stop_owned_process_falls_back_when_process_has_no_dedicated_group():
     from archivebox.opencode import views
 
     process = subprocess.Popen(["sleep", "60"])
-    views._stop_owned_process(process)
-
-    assert process.poll() is not None
+    try:
+        views._stop_owned_process(process)
+        assert process.poll() is not None
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
 
 
 def test_opencode_agent_requires_superuser_when_enabled(client, db, django_user_model, live_opencode):

--- a/archivebox/tests/test_opencode_agent.py
+++ b/archivebox/tests/test_opencode_agent.py
@@ -1,5 +1,6 @@
 import os
 import socket
+import subprocess
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
@@ -121,6 +122,15 @@ def test_opencode_disabled_route_does_not_start_server(client, initialized_archi
 
     assert response.status_code == 404
     assert views._PROCESS is None or views._PROCESS.poll() is not None
+
+
+def test_stop_owned_process_falls_back_when_process_has_no_dedicated_group():
+    from archivebox.opencode import views
+
+    process = subprocess.Popen(["sleep", "60"])
+    views._stop_owned_process(process)
+
+    assert process.poll() is not None
 
 
 def test_opencode_agent_requires_superuser_when_enabled(client, db, django_user_model, live_opencode):

--- a/archivebox/tests/test_opencode_agent.py
+++ b/archivebox/tests/test_opencode_agent.py
@@ -105,10 +105,7 @@ def live_opencode(opencode_archive_config):
     try:
         yield SimpleNamespace(config=opencode_archive_config, settings=settings, process=process)
     finally:
-        if views._PROCESS and views._PROCESS.poll() is None:
-            views._PROCESS.terminate()
-            views._PROCESS.wait(timeout=10)
-        views._PROCESS = None
+        views._stop_owned_process()
 
 
 def test_opencode_disabled_route_does_not_start_server(client, initialized_archive):


### PR DESCRIPTION
OpenCode can leave child server processes behind when only its launcher PID is terminated. Stop the dedicated process group created by `start_new_session=True`, and use the same lifecycle helper in the real integration fixture.

This fixes the rc415 CI evidence that GitHub had to terminate nine orphaned `opencode.exe` processes after the test job.

Verified with:
- `uv run pytest archivebox/tests/test_opencode_agent.py -q` (13 passed)
- before/after process-list diff: no new OpenCode server processes
- `uv run prek run --files archivebox/opencode/views.py archivebox/tests/test_opencode_agent.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the full OpenCode process group so child server processes are no longer orphaned when only the launcher PID is terminated.

**Bug Fixes**
- `_stop_owned_process` sends `SIGTERM`/`SIGKILL` to the process group with `os.killpg`, falling back to signaling the process directly when it has no dedicated group.
- Test fixture cleanup now calls `_stop_owned_process()` instead of manually terminating and clearing the process reference.
- Adds a regression test for the fallback when a process has no dedicated group.

<sup>Written for commit b364074cf88ffb951b3bbc7888009fa7891dc3d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/ArchiveBox/pull/1858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

