### PR TITLE
Disable OpenCode filesystem snapshots

### DIFF
--- a/archivebox/opencode/views.py
+++ b/archivebox/opencode/views.py
@@ -44,7 +44,8 @@ _CONFIG_PATH = Path(opencode_plugin.__file__).with_name("config.json")
 _DEFAULT_MODEL = "opencode/big-pickle"
 _DEFAULT_CONFIG = f'''{{
   "$schema": "https://opencode.ai/config.json",
-  "model": "{_DEFAULT_MODEL}"
+  "model": "{_DEFAULT_MODEL}",
+  "snapshot": false
 }}
 '''
 

--- a/archivebox/tests/test_opencode_agent.py
+++ b/archivebox/tests/test_opencode_agent.py
@@ -411,6 +411,7 @@ def test_opencode_starts_with_isolated_state(live_opencode):
     assert Path(live_opencode.settings["workdir"]).resolve() == Path(workdir)
     assert Path(str(project.json()["worktree"])).resolve() == Path(workdir)
     assert config.json()["model"] == "opencode/big-pickle"
+    assert config.json()["snapshot"] is False
     assert live_opencode.process.poll() is None
     assert (live_opencode.config.data_dir / ".git").is_dir()
     assert (state_dir / "data" / "opencode" / "opencode.db").is_file()
@@ -442,7 +443,9 @@ def test_opencode_state_dir_is_separate_from_workdir(tmp_path):
     assert loaded_skill.is_symlink()
     assert loaded_skill.resolve() == editable_skill.resolve()
     assert f"ArchiveBox collection directory: {settings['archivebox_data_dir']}" in editable_skill.read_text()
-    assert json.loads((state_dir / "config" / "opencode" / "opencode.jsonc").read_text())["model"] == "opencode/big-pickle"
+    opencode_config = json.loads((state_dir / "config" / "opencode" / "opencode.jsonc").read_text())
+    assert opencode_config["model"] == "opencode/big-pickle"
+    assert opencode_config["snapshot"] is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
OpenCode's own snapshot tracker should not `git add` an ArchiveBox collection. On a real `/data` project it traversed archived nested repositories, failed on their Git state, and left the agent request busy after the model had replied.

Generate fresh ArchiveBox-owned OpenCode config with `snapshot: false`. Existing OpenCode config remains entirely user-owned and untouched.

Verification:
- real config/server tests pass
- DigestBox `/data` smoke selected `opencode/big-pickle`, replied correctly, exited cleanly in 79s, and logged no snapshot traversal/failure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
OpenCode's snapshot tracker was `git add`-ing the ArchiveBox collection, failing on nested archived repos and leaving agent requests busy after the model replied. Disables filesystem snapshots for generated OpenCode configs by setting `snapshot: false`, and updates tests to assert the new config. Existing user-owned configs are left untouched.

<sup>Written for commit e7ff7cdad2ada4b14f809b929979606087ce32fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/ArchiveBox/pull/1868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

