### PR TITLE
Reuse agent request config and cover private OpenCode asset caching

### DIFF
--- a/archivebox/opencode/views.py
+++ b/archivebox/opencode/views.py
@@ -17,7 +17,7 @@ from django.urls import Resolver404, resolve
 from django.views.decorators.csrf import csrf_exempt
 
 from archivebox.config import CONSTANTS
-from archivebox.config.common import get_config, get_request_config
+from archivebox.config.common import get_request_config
 from archivebox.core.middleware import ReverseProxyAuthMiddleware
 from archivebox.core.routes_util import build_admin_url, get_admin_host, get_api_base_url, get_base_url, host_matches
 from archivebox.plugins.discovery import get_plugin_template
@@ -40,7 +40,7 @@ def _runtime_settings(request, config):
 
 def _dispatch(request, path=None):
     try:
-        config = dict(get_config().model_dump(mode="json"))
+        config = get_request_config(request).model_dump(mode="json")
         if not config.get("OPENCODE_ENABLED", False):
             raise Http404
         if not request.user.is_authenticated:
@@ -114,7 +114,7 @@ def _websocket_context(scope):
         SessionMiddleware(_dispatch).process_request(request)
         AuthenticationMiddleware(_dispatch).process_request(request)
         ReverseProxyAuthMiddleware(_dispatch).process_request(request)
-        config = get_config().model_dump(mode="json")
+        config = route_config.model_dump(mode="json")
         if not config.get("OPENCODE_ENABLED") or not request.user.is_active or not request.user.is_superuser:
             raise PermissionDenied
         runtime, settings = _runtime_settings(request, config)

--- a/archivebox/tests/conftest.py
+++ b/archivebox/tests/conftest.py
@@ -85,7 +85,7 @@ def _set_test_source_pythonpath(env: dict[str, str]) -> None:
         for entry in (env.get("PYTHONPATH") or "").split(os.pathsep)
         if entry and Path(entry).expanduser().is_absolute() and Path(entry).expanduser().exists()
     ]
-    entries = [entry for entry in [*source_pythonpath.split(os.pathsep), *existing_entries] if entry]
+    entries = [entry for entry in [*existing_entries, *source_pythonpath.split(os.pathsep)] if entry]
     if entries:
         env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(entries))
     else:

--- a/archivebox/tests/test_opencode_agent.py
+++ b/archivebox/tests/test_opencode_agent.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import re
 import shutil
 import socket
 from concurrent.futures import ThreadPoolExecutor
@@ -356,6 +357,25 @@ def test_opencode_proxy_preserves_protocol_headers(admin_client, live_opencode):
     finally:
         deleted = admin_client.delete(path, **headers)
     assert deleted.status_code == 200, deleted.content
+
+
+def test_opencode_static_assets_cache_privately_and_revalidate(admin_client, live_opencode):
+    headers = {"HTTP_HOST": ADMIN_TEST_HOST, "HTTP_SEC_FETCH_SITE": "same-origin"}
+    page = admin_client.get("/admin/agent/opencode/", **headers)
+    assert page.status_code == 200
+    asset = re.search(rb'src="(/admin/agent/opencode/assets/[^\"]+\.js)"', page.content)
+    assert asset is not None
+    path = asset[1].decode()
+    response = admin_client.get(path, **headers)
+    assert response.status_code == 200
+    assert "private" in response.headers["Cache-Control"]
+    assert "max-age=" in response.headers["Cache-Control"]
+    assert b"/admin/agent/opencode" in response.content
+    repeated = admin_client.get(path, HTTP_IF_NONE_MATCH=response.headers["ETag"], **headers)
+    assert repeated.status_code == 304
+    assert repeated.content == b""
+    assert repeated.headers["ETag"] == response.headers["ETag"]
+    assert admin_client.get("/admin/agent/opencode/path", **headers).headers["Cache-Control"] == "no-store"
 
 
 def test_opencode_proxy_sse_response_is_unbuffered(admin_client, live_opencode):

--- a/archivebox/tests/test_opencode_agent.py
+++ b/archivebox/tests/test_opencode_agent.py
@@ -490,7 +490,7 @@ def test_opencode_starts_with_isolated_state(admin_client, live_opencode):
     assert Path(live_opencode.settings["workdir"]).resolve() == Path(workdir)
     assert project.json()["id"] == "global"
     assert not project.json().get("vcs")
-    assert config.json()["model"] == "opencode/big-pickle"
+    assert not config.json().get("model")
     assert config.json()["snapshot"] is False
     assert live_opencode.process.poll() is None
     path = requests.get(


### PR DESCRIPTION
Changes pushed directly to archivebox:dev at 6f8e3b7 as requested. Full real OpenCode agent/browser regression suite: 30 passed, 6 deprecation warnings. CI handles dependency release propagation and version bumps; no manual version changes.